### PR TITLE
sets onChange in SelectPicker to fix Failed prop type warning

### DIFF
--- a/src/SelectPicker/index.tsx
+++ b/src/SelectPicker/index.tsx
@@ -86,6 +86,7 @@ const SelectPicker = ({
             value={option.value}
             name={name}
             checked={isSelected(option)}
+            onChange={() => {}}
           />
           <Flex>
             {option.image && <CardImage src={option.image} />}


### PR DESCRIPTION
Since `onChange` is already being invoked in `onPickerClick` and `useEffect`, I assume this means it'll be called again. Not sure if this is negligible or not, but it fixes the warning