### PR TITLE
enables toggling of checkbox in storybook

### DIFF
--- a/src/Checkbox/Checkbox.stories.js
+++ b/src/Checkbox/Checkbox.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import useState from 'storybook-addon-state'
 import CheckBox from './index'
 
 storiesOf('Checkbox', module)
@@ -18,5 +19,12 @@ storiesOf('Checkbox', module)
     <div style={{ margin: '50px auto' }}>{storyFn()}</div>
   ))
   .add('Default', () => {
-    return <CheckBox label="Click me!" />
+    const [checked, setChecked] = useState('checked', false)
+    return (
+      <CheckBox
+        label="Click me!"
+        checked={checked}
+        onChange={() => setChecked(!checked)}
+      />
+    )
   })

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -11,7 +11,7 @@ interface CheckboxProps {
 
 const CheckBox = ({ label, checked, onChange, name, id }: CheckboxProps) => {
   return (
-    <Checkbox>
+    <Checkbox onClick={onChange}>
       <input
         type="checkbox"
         name={name}


### PR DESCRIPTION
Resolves https://github.com/purple-technology/phoenix-components/issues/30

the `onChange` event would not fire in the storybook. I compared it to `SelectPicker` and made it work the same way by handing an `onClick` event to the styled `div` that wraps the `input` element