### PR TITLE
adds missing semi-colon to Input's Error component styling

### DIFF
--- a/src/Input/InputStyles.tsx
+++ b/src/Input/InputStyles.tsx
@@ -114,7 +114,7 @@ export const StyledFloatingLabel = styled<any>(FloatingLabel)`
 export const Error = styled.div<any>`
   color: rgba(204, 0, 0, 0.82);
   position: ${({ disableAbsolutePositionError }: any) =>
-    disableAbsolutePositionError ? 'relative' : 'absolute'}
+    disableAbsolutePositionError ? 'relative' : 'absolute'};
   padding: 5px 0;
   font-size: 12px;
 `


### PR DESCRIPTION
when previewing the component with storybook, the `;` was automatically added for us, but it's not getting automatically added for some of the downstream projects