### PR TITLE
removes storybook-addon-state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12695,12 +12695,6 @@
       "integrity": "sha512-JmK+95jLX2zAP75DVAJ1HAziQ6f+f495h4P9ez2qbmxazN6fE7doWlitqx9hj2YohH3kOi6RVksJe1UH0sJfPw==",
       "dev": true
     },
-    "storybook-addon-state": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/storybook-addon-state/-/storybook-addon-state-1.0.3.tgz",
-      "integrity": "sha512-0lpedSYu2xIlq4QK/8YH4Cuj6vt2p8iRCcJBb4JFxyLZ6RAMHFFkf072BKl4WrU1LfLq3/7SD4snvxRoTjvsvw==",
-      "dev": true
-    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "rollup": "^1.20.3",
     "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-typescript2": "^0.24.0",
-    "storybook-addon-state": "^1.0.3",
     "styled-components": "^4.3.1",
     "typescript": "^3.5.3",
     "webpack-cli": "^3.3.1"

--- a/src/CheckBox/Checkbox.stories.js
+++ b/src/CheckBox/Checkbox.stories.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import useState from 'storybook-addon-state'
+import { Store, StateDecorator } from '@sambego/storybook-state'
+
 import CheckBox from './index'
+
+const store = new Store({
+  checked: false
+})
 
 storiesOf('Checkbox', module)
   .addParameters({
@@ -15,16 +20,18 @@ storiesOf('Checkbox', module)
       header: false
     }
   })
+  .addDecorator(StateDecorator(store))
   .addDecorator(storyFn => (
     <div style={{ margin: '50px auto' }}>{storyFn()}</div>
   ))
   .add('Default', () => {
-    const [checked, setChecked] = useState('checked', false)
     return (
       <CheckBox
         label="Click me!"
-        checked={checked}
-        onChange={() => setChecked(!checked)}
+        checked={store.get('checked')}
+        onChange={ev => {
+          store.set({ checked: !store.get('checked') })
+        }}
       />
     )
   })


### PR DESCRIPTION
In all the other stories, we're using `@sambego/storybook-state`. To be more consistent, I refactored `Checkbox` to use this as well and removed `storybook-addon-state` as a dependency. This way, we're only using one package for this one purpose