### PR TITLE
fixes warning about non bool prop in Input

### DIFF
--- a/src/Input/index.tsx
+++ b/src/Input/index.tsx
@@ -12,6 +12,7 @@ import {
   StyledDescription
 } from './InputStyles'
 import theme from '../theme'
+import { nonDomPropResolve } from '../helpers'
 
 import { IoIosCheckmark } from 'react-icons/io'
 
@@ -98,7 +99,7 @@ const Input = ({
             error={error}
             type={type}
             inputMode={inputmode}
-            success={success}
+            success={nonDomPropResolve(success)}
             onFocus={thisOnFocus}
             onBlur={thisOnBlur}
             onChange={onChange}

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -1,0 +1,12 @@
+/** Use to avoid warnings from styled, custom components
+ *
+ * When mixing styled-components with custom react components,
+ * all props are passed through, meaning the custom props are
+ * not cleaned from standard attributes for HTML DOM elements.
+ *
+ * This method offers a work-around to avoid the resulting
+ * (inconsequential) error
+ */
+export const nonDomPropResolve = (value: boolean) => {
+  return value ? 1 : 0
+}


### PR DESCRIPTION
the error is inconsequential, but it's certainly distracting for development, and gets carried into code which implements the component. While I don't like writing code just to get around an error, I think having a dedicated helper function that can be re-used is a decent way to do it

Resolves https://github.com/purple-technology/phoenix-components/issues/79