### PR TITLE
replaces Select label's hardcoded fontsize

### DIFF
--- a/src/SelectBox/SelectStyles.tsx
+++ b/src/SelectBox/SelectStyles.tsx
@@ -80,7 +80,7 @@ export const PlaceholderText = styled.span<PlaceholderTextProps>`
     placeholderUp ? '9px' : '22px'};
   left: 15px;
   font-size: ${({ placeholderUp }: PlaceholderTextProps) =>
-    placeholderUp ? '12px' : '15px'};
+    placeholderUp ? '0.8rem' : '1rem'};
   color: ${({ placeholderUp, error, success, theme }: PlaceholderTextProps) =>
     placeholderUp
       ? getColor(error, theme.colors.error, success, theme.colors.success)


### PR DESCRIPTION
We have the font size hardcoded for the select input, and it's hard to override since the component is nested so deeply. I've preserved the same ratio and the text still shrinks by 20% when the label is up