### PR TITLE
makes PDF width 90% of container like image files in FileUpload

### DIFF
--- a/src/FileUpload/FileUploadStyle.tsx
+++ b/src/FileUpload/FileUploadStyle.tsx
@@ -25,6 +25,7 @@ export const PreviewFilesWrapper = styled.div`
 export const SinglePreview = styled.div``
 
 export const RelativeWrap = styled.div`
+  max-width: 140px;
   position: relative;
 `
 

--- a/src/FileUpload/components/FilePreview.tsx
+++ b/src/FileUpload/components/FilePreview.tsx
@@ -21,7 +21,7 @@ export const StyledFilePreview = styled.img`
 // Must be copied because we can't inherit from a styled.img
 // And can't go other way because TypeScript doesn't recognize polymorhphic props
 export const StyledPdfFilePreview = styled.div`
-  max-width: 125px;
+  max-width: 90%;
   max-height: 150px;
   overflow: hidden;
   padding: 10px;


### PR DESCRIPTION
When the FileUpload is squashed, since we have auto horizontal margins, the images still have spacing but the PDFs don't in FileUpload. I set the PDF preview component to use `width: 90%` so they'd have the exact spacing as the images, but to accomplish this I had to set a max width on the parent component. This prevents the PDFs from eating up the entire page. It could possibly affect images as well