### PR TITLE
fix: changed main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@purple/phoenix-components",
   "version": "2.10.0",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/bundle.umd.js",
   "module": "dist/bundle.esm.js",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: main field in package.json no longer points to dist/index.js but to dist/bundle.umd.js

dist/index.js does not exist when the package has been published. This is fine for webpack/nextjs because they look for the module field in package.json. Which has been set correctly.

But jest resolves a package using the main field which in our case was point to a file which didn't exist, causing unit tests to fail.