### PR TITLE
fix: add type definitions to package.json as main is no longer index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/bundle.umd.js",
   "module": "dist/bundle.esm.js",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
Turns out if you set main in package.json to something other than index.js, you also need to set the types property on the package.json to point to the type definitions. Again nextjs works without this but jest does need the types property in order to pick up the type definitions

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html