### PR TITLE
RTL support improved and optimized

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,9 @@ module.exports = {
 		'@storybook/addon-a11y',
 
 		// Connect our Storybook with Figma design
-		'storybook-addon-designs'
+		'storybook-addon-designs',
+
+		// A storybook addons that lets your users toggle between ltr and rtl.
+		'@pxblue/storybook-rtl-addon/register'
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.9.0](https://github.com/purple-technology/phoenix-components/compare/v4.8.1...v4.9.0) (2021-09-10)
+
+
+### Features
+
+* allow tiny size for form control components ([4fd6374](https://github.com/purple-technology/phoenix-components/commit/4fd6374470afe4e5788d243ee0b4a3b34045ddf8))
+* rtl support improved and optimized ([cb5278a](https://github.com/purple-technology/phoenix-components/commit/cb5278ac68eac6b0d061162778b72fa40c5da38b))
+
+
+### Bug Fixes
+
+* **buttongroup:** spaces between buttons in storybook story ([2b3043c](https://github.com/purple-technology/phoenix-components/commit/2b3043c8d5653051818f38b3a0d7949092412927))
+* preview width of an example form in storybook ([8673455](https://github.com/purple-technology/phoenix-components/commit/8673455ba38794ad97ef569ab2e7366bc19fbbbc))
+
 ### [4.8.1](https://github.com/purple-technology/phoenix-components/compare/v4.8.0...v4.8.1) (2021-08-25)
 
 ## [4.8.0](https://github.com/purple-technology/phoenix-components/compare/v4.7.2...v4.8.0) (2021-08-25)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Phoenix Components takes advantage of some 3rd party libraries to create consist
 
 2. Import `Theme` from Phoenix Components and wrap the app in `<ThemeProvider>` from `styled-components` providing the `Theme` object. If your repository already contains custom `styled-components` theme, merge both themes together. Merge should be safe as Phoenix Components use only the object with key `$pc`.
 
-Also, import `<GlobalStyles>` component which provides styles such as default font and sizes, and include it once in your project.
+    Also, import `<GlobalStyles>` component which provides styles such as default font and sizes, and include it once in your project.
 
 ```typescript
 import { ThemeProvider } from 'styled-components'
@@ -53,6 +53,14 @@ function App() {
     </ThemeProvider>
   )
 }
+```
+
+You can optionally include `dir` key in the theme with values either `'ltr'` or `'rtl'`. This is not required but it will slightly optimize CSS generated to support right-to-left layouts, resulting in smaller footprint.
+
+```typescript
+...
+<ThemeProvider theme={{ dir: 'rtl', ...Theme }}>
+...
 ```
 
 3. Import components that you need and use them according to [the docs](https://purple-technology.github.io/phoenix-components).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.8.1",
+	"version": "4.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,6 +2719,12 @@
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz",
 			"integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ=="
 		},
+		"@pxblue/storybook-rtl-addon": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@pxblue/storybook-rtl-addon/-/storybook-rtl-addon-1.0.1.tgz",
+			"integrity": "sha512-N/HysEo6rK7f0Eqm4xt8nciZXwjdNscRD5hSYUZUZEn4EzdtqwqXSel8jfjUuZ9R6YCQ7+IIqdZsk6gHUlS+qw==",
+			"dev": true
+		},
 		"@reach/router": {
 			"version": "1.3.4",
 			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"@commitlint/cli": "^12.1.4",
 		"@commitlint/config-conventional": "^12.1.4",
 		"@percy/storybook": "^3.3.1",
+		"@pxblue/storybook-rtl-addon": "^1.0.1",
 		"@rollup/plugin-node-resolve": "^13.0.4",
 		"@rollup/plugin-typescript": "^8.2.1",
 		"@rollup/plugin-url": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.8.1",
+	"version": "4.9.0",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -25,10 +25,10 @@ interface ButtonGroupStoryProps extends ButtonGroupProps {
 
 export const ButtonGroup: Story<ButtonGroupStoryProps> = (args) => (
 	<ButtonGroupComponent {...args}>
-		<Button size={args.size} colorTheme={'success'} icon="deposit" mr="m">
+		<Button size={args.size} colorTheme={'success'} icon="deposit" mr="xxs">
 			Deposit
 		</Button>
-		<Button size={args.size} icon="withdrawal" minimal>
+		<Button size={args.size} icon="withdrawal" minimal mr="xxs">
 			Withdraw
 		</Button>
 		<Button size={args.size} icon="transfer" minimal>

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,7 +1,10 @@
 import { Story } from '@storybook/react'
 import React from 'react'
 
-import { ComponentSize } from '../../types/ComponentSize'
+import {
+	ComponentSize,
+	ComponentSizeSmallMediumLarge
+} from '../../types/ComponentSize'
 import { Button } from '../Button'
 import { ButtonGroup as ButtonGroupComponent, ButtonGroupProps } from './index'
 
@@ -11,7 +14,7 @@ export default {
 	argTypes: {
 		size: {
 			control: 'radio',
-			options: ['small', 'medium', 'large']
+			options: ComponentSizeSmallMediumLarge
 		}
 	}
 }
@@ -22,7 +25,7 @@ interface ButtonGroupStoryProps extends ButtonGroupProps {
 
 export const ButtonGroup: Story<ButtonGroupStoryProps> = (args) => (
 	<ButtonGroupComponent {...args}>
-		<Button size={args.size} colorTheme={'success'} icon="deposit">
+		<Button size={args.size} colorTheme={'success'} icon="deposit" mr="m">
 			Deposit
 		</Button>
 		<Button size={args.size} icon="withdrawal" minimal>

--- a/src/components/Checkbox/CheckboxStyles.tsx
+++ b/src/components/Checkbox/CheckboxStyles.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 import checkmark from '../../images/check.svg'
+import { left } from '../../utils/rtl'
 import { CommonStyledCheckboxRadio } from '../common/CheckboxRadio/CheckboxRadioStyles'
 
 export const StyledCheckbox = styled(CommonStyledCheckboxRadio)`
@@ -14,17 +15,17 @@ export const StyledCheckbox = styled(CommonStyledCheckboxRadio)`
 		${({ size }): string =>
 			size === 'large'
 				? `
-			height: 11px;
-			width: 16px;
-			left: 4px;
-			top: 6px;
-		`
+						height: 11px;
+						width: 16px;
+						top: 6.5px;
+				  `
 				: `
-			height: 10px;
-			width: 12px;
-			left: 4px;
-			top: 5px;
+						height: 10px;
+						width: 12px;
+						top: 5px;				
 		`}
+
+		${left('4px')}
 	}
 
 	input:checked + label::before {

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -13,15 +13,11 @@ export const Checkbox: React.VoidFunctionComponent<CheckboxProps> = ({
 	size = 'medium',
 	colorTheme = 'primary',
 	className,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	...props
 }) => (
-	<StyledCheckbox
-		className={className}
-		dir={RTL ? 'rtl' : 'ltr'}
-		colorTheme={colorTheme}
-		size={size}
-	>
+	<StyledCheckbox className={className} colorTheme={colorTheme} size={size}>
 		<CheckboxRadio type="checkbox" {...props} />
 	</StyledCheckbox>
 )

--- a/src/components/ClosableButton/ClosableButtonStyles.tsx
+++ b/src/components/ClosableButton/ClosableButtonStyles.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 
+import { right } from '../../utils/rtl'
 import {
 	getBaseStyles,
 	getColorThemeStyles,
@@ -16,7 +17,7 @@ export const Button = styled.button`
 	${(props): string => getSizeRelatedStyles('small', props.theme)}
 	${(props): string => getColorThemeStyles(props.theme, 'neutral', false, true)}
 	
-	padding-right: 36px;
+	padding-inline-end: 36px;
 	font-weight: 400;
 `
 
@@ -27,7 +28,7 @@ export const Close = styled.button`
 	
 	position: absolute;
 	top: 0;
-	right: 0;
+	${right(0)}
 	padding: 0 12px;
 	width: 36px;
 	background: transparent;

--- a/src/components/ClosableItem/ClosableItemStyles.tsx
+++ b/src/components/ClosableItem/ClosableItemStyles.tsx
@@ -1,10 +1,6 @@
 import styled from 'styled-components'
 
-import {
-	getBaseStyles,
-	getColorThemeStyles,
-	getSizeRelatedStyles
-} from '../common/Button/ButtonStyles'
+import { getSizeRelatedStyles } from '../common/Button/ButtonStyles'
 
 export const Wrapper = styled.div`
 	position: relative;
@@ -20,18 +16,5 @@ export const Content = styled.div`
 	cursor: default;
 	background: ${({ theme }): string => theme.$pc.colors.neutral.light};
 	color: ${({ theme }): string => theme.$pc.colors.text.darkest};
-	padding-right: 36px;
-`
-
-export const Close = styled.button`
-	${(props): string => getBaseStyles(props.theme)}
-	${(props): string => getSizeRelatedStyles('small', props.theme)}
-	${(props): string => getColorThemeStyles(props.theme, 'neutral', true)}
-	
-	position: absolute;
-	top: 0;
-	right: 0;
-	padding: 0 12px;
-	width: 36px;
-	background: transparent;
+	padding-inline-end: 36px;
 `

--- a/src/components/ClosableItem/index.tsx
+++ b/src/components/ClosableItem/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
 import iconTimes from '../../images/times.svg'
-import { Close, Content, Wrapper } from './ClosableItemStyles'
+import { Close } from '../ClosableButton/ClosableButtonStyles'
+import { Content, Wrapper } from './ClosableItemStyles'
 
 export interface ClosableItemProps {
 	onClose?: () => void

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -70,6 +70,7 @@ export interface DateInputProps {
 	/** The locality the date format should follow */
 	locale?: 'eu' | 'us' | 'ja'
 	className?: string
+	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
 	RTL?: boolean
 	size?: ComponentSizeSmallMediumLarge
 	disabled?: boolean
@@ -154,7 +155,6 @@ export const DateInput: React.FC<DateInputProps> = ({
 			onBlur={handleOnBlur}
 			error={!!error}
 			size={size}
-			RTL={props.RTL}
 			success={props.success}
 			disabled={props.disabled}
 		/>
@@ -169,7 +169,6 @@ export const DateInput: React.FC<DateInputProps> = ({
 			options={monthOptions}
 			error={!!error}
 			size={size}
-			RTL={props.RTL}
 			success={props.success}
 			disabled={props.disabled}
 		/>
@@ -187,7 +186,6 @@ export const DateInput: React.FC<DateInputProps> = ({
 			onBlur={handleOnBlur}
 			error={!!error}
 			size={size}
-			RTL={props.RTL}
 			success={props.success}
 			disabled={props.disabled}
 		/>

--- a/src/components/DatePicker/DatePickerStyles.tsx
+++ b/src/components/DatePicker/DatePickerStyles.tsx
@@ -9,6 +9,10 @@ export const StyledDatePicker = styled(CommonDatePicker)`
 		padding-bottom: 0.75em;
 	}
 
+	.DayPicker-Caption {
+		text-align: start;
+	}
+
 	.DayPicker-Caption > div {
 		font-size: 18px;
 		overflow: hidden;
@@ -17,8 +21,14 @@ export const StyledDatePicker = styled(CommonDatePicker)`
 		width: 150px;
 	}
 
+	[dir='rtl'] & .DayPicker-NavButton {
+		right: initial;
+		left: 1.5em;
+		transform: scaleX(-1);
+	}
+
 	.DayPicker-NavButton--prev {
-		margin-right: 2em;
+		margin-inline-end: 2em;
 		background-image: url(${imgArrowLeft});
 	}
 

--- a/src/components/DateRangePicker/DateRangePickerStyles.tsx
+++ b/src/components/DateRangePicker/DateRangePickerStyles.tsx
@@ -20,4 +20,16 @@ export const StyledDateRangePicker = styled(StyledDatePicker)`
 		border-top-right-radius: 50% !important;
 		border-bottom-right-radius: 50% !important;
 	}
+	[dir='rtl'] &.DateRangePicker .DayPicker-Day--start {
+		border-top-right-radius: 50% !important;
+		border-bottom-right-radius: 50% !important;
+		border-top-left-radius: 0 !important;
+		border-bottom-left-radius: 0 !important;
+	}
+	[dir='rtl'] &.DateRangePicker .DayPicker-Day--end {
+		border-top-left-radius: 50% !important;
+		border-bottom-left-radius: 50% !important;
+		border-top-right-radius: 0 !important;
+		border-bottom-right-radius: 0 !important;
+	}
 `

--- a/src/components/Heading/HeadingStyles.tsx
+++ b/src/components/Heading/HeadingStyles.tsx
@@ -5,13 +5,17 @@ import { HeadingSizes } from '.'
 
 interface StyledHeadingProps {
 	as: HeadingSizes
-	size?: string
+	size?: string | number
 	bold?: boolean
 }
 
 export const StyledHeading = styled.h1<StyledHeadingProps>`
 	font-size: ${({ size, theme, as }): string =>
-		size ?? `${theme.$pc.heading.size[as]}px`};
+		size
+			? typeof size === 'number'
+				? `${size}px`
+				: size
+			: `${theme.$pc.heading.size[as]}px`};
 	font-weight: ${({ as, bold }): number =>
 		bold === false || (typeof bold === 'undefined' && as === 'h1') ? 400 : 500};
 	color: ${({ theme }): string => theme.$pc.colors.text.darkest};

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -14,7 +14,7 @@ export interface HeadingProps
 	/** Size of the heading - h1, h2, h3 or h4 */
 	element?: HeadingSizes
 	/** Any CSS size value with valid unit (4px, .5rem, 50% etc.), overriding the default heading size. */
-	size?: string
+	size?: string | number
 }
 
 export const Heading: React.FC<HeadingProps> = ({

--- a/src/components/Link/LinkStyles.tsx
+++ b/src/components/Link/LinkStyles.tsx
@@ -27,7 +27,9 @@ export const styledIconCss = css<StyledIconProps>`
 	height: 1em;
 	vertical-align: -0.15em;
 	${({ $iconAlignment }): string =>
-		$iconAlignment === 'left' ? 'margin-right: .4em;' : 'margin-left: .4em;'}
+		$iconAlignment === 'left'
+			? 'margin-inline-end: .4em;'
+			: 'margin-inline-start: .4em;'}
 `
 
 export const StyledCustomIcon = styled(SVG)`

--- a/src/components/Menu/MenuStyles.tsx
+++ b/src/components/Menu/MenuStyles.tsx
@@ -10,7 +10,7 @@ export const StyledMenu = styled.ul`
 	list-style: none;
 	margin: 0;
 	min-width: 180px;
-	text-align: left;
+	text-align: start;
 
 	${paddingCss}
 `
@@ -41,7 +41,7 @@ export const StyledMenuItemAnchor = styled.a`
 export const styledIconCss = css`
 	width: 20px;
 	height: 20px;
-	margin-right: 8px;
+	margin-inline-end: 8px;
 
 	path {
 		fill: ${({ theme }): string => theme.$pc.colors.text.dark};

--- a/src/components/Notice/NoticeStyles.tsx
+++ b/src/components/Notice/NoticeStyles.tsx
@@ -50,7 +50,7 @@ export const CloseButton = styled.button<CloseButtonProps>`
 	${({ paddingLeft }): string =>
 		paddingLeft
 			? `
-				margin-left: 1.5rem;
+				margin-inline-start: 1.5rem;
 		`
 			: ''}
 `

--- a/src/components/Paragraph/index.tsx
+++ b/src/components/Paragraph/index.tsx
@@ -11,7 +11,7 @@ export interface ParagraphProps
 		PaddingProps,
 		MarginProps {
 	/** Text size - small, medium, large; or overriding these basic styles with any CSS value with valid unit (px, rem, % etc.) */
-	size?: ComponentSizeSmallMediumLarge | string
+	size?: ComponentSizeSmallMediumLarge | string | number
 }
 
 /**

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -13,15 +13,11 @@ export const Radio: React.VoidFunctionComponent<RadioProps> = ({
 	size = 'medium',
 	colorTheme = 'primary',
 	className,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	...props
 }) => (
-	<StyledRadio
-		className={className}
-		dir={RTL ? 'rtl' : 'ltr'}
-		colorTheme={colorTheme}
-		size={size}
-	>
+	<StyledRadio className={className} colorTheme={colorTheme} size={size}>
 		<CheckboxRadio type="radio" {...props} />
 	</StyledRadio>
 )

--- a/src/components/SelectNative/SelectNativeStyles.tsx
+++ b/src/components/SelectNative/SelectNativeStyles.tsx
@@ -1,18 +1,21 @@
 import SVG from 'react-inlinesvg'
-import styled from 'styled-components'
+import styled, {
+	DefaultTheme,
+	FlattenInterpolation,
+	ThemeProps
+} from 'styled-components'
 
+import { right } from '../../utils/rtl'
 import { getHoverFieldsetStyles } from '../common/FormControl/FormControlStyles'
 
 interface StyledAngleDownProps {
-	$RTL?: boolean
 	disabled?: boolean
 }
 
 export const StyledAngleDown = styled(SVG)<StyledAngleDownProps>`
-	${({ theme, $RTL }): string =>
-		$RTL
-			? `left: ${theme.$pc.formControl.paddingX}px;`
-			: `right: ${theme.$pc.formControl.paddingX}px;`}
+	${({ theme }): FlattenInterpolation<ThemeProps<DefaultTheme>> =>
+		right(`${theme.$pc.formControl.paddingX}px`)}
+
 	position: absolute;
 	width: 10px;
 	height: 6px;

--- a/src/components/SelectNative/index.tsx
+++ b/src/components/SelectNative/index.tsx
@@ -40,7 +40,6 @@ export const SelectNative: React.FC<SelectNativeProps> = ({
 			warning={props.warning}
 			error={props.error}
 			contentRight={props.contentRight}
-			RTL={props.RTL}
 			className={props.className}
 			size={size}
 			disabled={props.disabled}
@@ -56,7 +55,6 @@ export const SelectNative: React.FC<SelectNativeProps> = ({
 					focused={focused}
 					disabled={props.disabled}
 					$size={size}
-					RTL={props.RTL}
 				>
 					<option />
 					{options.map((option, index) => (
@@ -69,11 +67,7 @@ export const SelectNative: React.FC<SelectNativeProps> = ({
 						</option>
 					))}
 				</StyledSelectNative>
-				<StyledAngleDown
-					src={iconAngleDown}
-					$RTL={props.RTL}
-					disabled={props.disabled}
-				/>
+				<StyledAngleDown src={iconAngleDown} disabled={props.disabled} />
 			</StyledSelectNativeWrapper>
 		</FormControl>
 	)

--- a/src/components/SelectPicker/SelectPickerStyles.tsx
+++ b/src/components/SelectPicker/SelectPickerStyles.tsx
@@ -1,10 +1,17 @@
-import styled, { DefaultTheme } from 'styled-components'
+import styled, {
+	css,
+	DefaultTheme,
+	FlattenInterpolation,
+	FlattenSimpleInterpolation,
+	ThemeProps
+} from 'styled-components'
 
 import { ButtonColorTheme } from '../../types/ColorTheme'
 import {
 	ComponentSize,
 	ComponentSizeMediumLarge
 } from '../../types/ComponentSize'
+import { left } from '../../utils/rtl'
 import { StyledCheckbox } from '../Checkbox/CheckboxStyles'
 
 const getCheckboxOffset = (
@@ -82,25 +89,28 @@ export const Option = styled.div<OptionProps>`
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	padding: ${({ withImage, checked, size, theme }): string => {
+	${({ withImage, checked, size, theme }): FlattenSimpleInterpolation => {
 		const horizontalPadding = getCheckboxOffset(size, theme)
 		const checkboxSize = theme.$pc.checkboxRadio.size[size]
 		/** 2 = border width, 16 = height of one-line text */
 		const verticalPadding = (theme.$pc.button.height[size] - 2 - 16) / 2
 
 		if (withImage) {
-			return `${verticalPadding + 4}px ${horizontalPadding}px`
+			return css`
+				padding: ${verticalPadding + 4}px ${horizontalPadding}px;
+			`
 		}
 
 		return checked
-			? `
-  		${verticalPadding}px ${horizontalPadding}px ${verticalPadding}px ${
-					2 * horizontalPadding + checkboxSize
-			  }px
-  	`
-			: `
-  		${verticalPadding}px ${horizontalPadding}px
-  	`
+			? css`
+					padding-top: ${verticalPadding}px;
+					padding-inline-end: ${horizontalPadding}px;
+					padding-bottom: ${verticalPadding}px;
+					padding-inline-start: ${2 * horizontalPadding + checkboxSize}px;
+			  `
+			: css`
+					padding: ${verticalPadding}px ${horizontalPadding}px;
+			  `
 	}};
 	text-align: center;
 	border: 1px solid;
@@ -170,7 +180,8 @@ interface CheckboxProps {
 export const Checkbox = styled(StyledCheckbox)<CheckboxProps>`
 	position: absolute;
 	top: ${({ size, theme }): number => getCheckboxOffset(size, theme)}px;
-	left: ${({ size, theme }): number => getCheckboxOffset(size, theme)}px;
+	${({ size, theme }): FlattenInterpolation<ThemeProps<DefaultTheme>> =>
+		left(`${getCheckboxOffset(size, theme)}px`)};
 	visibility: ${({ checked }): string => (checked ? 'visible' : 'hidden')};
 	pointer-events: none;
 `
@@ -184,7 +195,7 @@ export const Error = styled.div`
 
 /** Hack to visually center text */
 export const OptionLabel = styled.div`
-	left: -5%;
+	${left('-5%')}
 	transform: translateX(6%);
 	position: relative;
 `

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -8,7 +8,7 @@ import { StyledText } from './TextStyles'
 
 export interface TextProps extends CommonTextProps, PaddingProps, MarginProps {
 	/** Text size - small, medium, large; or overriding these basic styles with any CSS value with valid unit (px, rem, % etc.) */
-	size?: ComponentSizeSmallMediumLarge | string
+	size?: ComponentSizeSmallMediumLarge | string | number
 	/** Indicates that this component should be truncated with an ellipsis if it overflows its container. The `title` attribute will also be added when content overflows to show the full text of the children on hover. */
 	ellipsize?: boolean
 	element?: 'div' | 'span'

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -20,6 +20,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
 	error,
 	contentRight,
 	helperText,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	className,
 	...props
@@ -36,7 +37,6 @@ export const TextArea: React.FC<TextAreaProps> = ({
 				error={error}
 				contentRight={contentRight}
 				helperText={helperText}
-				RTL={RTL}
 				className={className}
 				size={size}
 				disabled={props.disabled}

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -20,6 +20,7 @@ export const TextInput: React.FC<TextInputProps> = ({
 	error,
 	contentRight,
 	helperText,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	className,
 	...props
@@ -37,7 +38,6 @@ export const TextInput: React.FC<TextInputProps> = ({
 			error={error}
 			contentRight={contentRight}
 			helperText={helperText}
-			RTL={RTL}
 			className={className}
 			size={size}
 			disabled={props.disabled}

--- a/src/components/common/Button/ButtonIcon.tsx
+++ b/src/components/common/Button/ButtonIcon.tsx
@@ -2,19 +2,17 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { ComponentSize } from '../../../types/ComponentSize'
-import { IconAlignment } from '../../../types/IconAlignment'
 import { IconType } from '../../../types/IconType'
 import { PhoenixIconsOutlined } from '../../../types/PhoenixIcons'
 import { StyledCustomIcon, StyledIcon, styledIconCss } from './ButtonStyles'
 
 interface IconProps {
 	icon?: IconType
-	iconAlignment?: IconAlignment
 	size: ComponentSize
 }
 
 const ButtonIcon: React.FC<IconProps> = (props) => {
-	if (!props.icon || !props.iconAlignment) {
+	if (!props.icon) {
 		return null
 	}
 
@@ -22,32 +20,20 @@ const ButtonIcon: React.FC<IconProps> = (props) => {
 		return (
 			<StyledIcon
 				icon={props.icon as PhoenixIconsOutlined}
-				$iconAlignment={props.iconAlignment}
 				$size={props.size}
 			/>
 		)
 	}
 
 	if (typeof props.icon === 'string') {
-		return (
-			<StyledCustomIcon
-				src={props.icon}
-				$iconAlignment={props.iconAlignment}
-				$size={props.size}
-			/>
-		)
+		return <StyledCustomIcon src={props.icon} $size={props.size} />
 	}
 
 	const StyledCustomElement = styled(props.icon)`
 		${styledIconCss}
 	`
 
-	return (
-		<StyledCustomElement
-			$iconAlignment={props.iconAlignment}
-			$size={props.size}
-		/>
-	)
+	return <StyledCustomElement $size={props.size} />
 }
 
 export default ButtonIcon

--- a/src/components/common/Button/ButtonStyles.tsx
+++ b/src/components/common/Button/ButtonStyles.tsx
@@ -1,5 +1,9 @@
 import SVG from 'react-inlinesvg'
-import styled, { css, DefaultTheme } from 'styled-components'
+import styled, {
+	css,
+	DefaultTheme,
+	FlattenSimpleInterpolation
+} from 'styled-components'
 
 import { ButtonColorTheme } from '../../../types/ColorTheme'
 import { ComponentSize } from '../../../types/ComponentSize'
@@ -180,7 +184,7 @@ const commonButtonStyles = css<ButtonWrapperProps>`
 		)}
 
 	/** These styles are specific for stand-alone component Button */
-	text-align: ${({ icon }): string => (icon ? 'left' : 'center')};
+	text-align: ${({ icon }): string => (icon ? 'start' : 'center')};
 
 	${marginCss}
 `
@@ -194,22 +198,34 @@ export const LinkButtonWrapper = styled.a<ButtonWrapperProps>`
 `
 
 interface ButtonTextProps {
-	withIcon: boolean
+	icon?: boolean
+	iconAlignment?: IconAlignment
 }
 
 export const ButtonText = styled.div<ButtonTextProps>`
 	flex: 1;
 	display: flex;
+	${({
+		children,
+		icon,
+		iconAlignment
+	}): FlattenSimpleInterpolation | undefined =>
+		children && icon
+			? iconAlignment === 'left'
+				? css`
+						margin-inline-start: 0.6em;
+				  `
+				: css`
+						margin-inline-end: 0.6em;
+				  `
+			: undefined}
 `
 
 interface StyledIconProps {
-	$iconAlignment: IconAlignment
 	$size: ComponentSize
 }
 
 export const styledIconCss = css<StyledIconProps>`
-	${({ $iconAlignment }): string =>
-		$iconAlignment === 'left' ? 'margin-right: .6em;' : 'margin-left: .6em;'}
 	${({ theme, $size }): string => `
 		width: ${theme.$pc.button.iconSize[$size] + 'px'};
 		height: ${theme.$pc.button.iconSize[$size] + 'px'};

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -37,15 +37,13 @@ const ButtonInner: React.FC<CommonButtonProps> = ({
 			<ButtonLoader size={size} colorTheme={colorTheme} light={light} />
 		)}
 		<ButtonContent $loading={loading}>
-			{iconAlignment === 'left' && (
-				<ButtonIcon icon={icon} iconAlignment={iconAlignment} size={size} />
-			)}
+			{iconAlignment === 'left' && <ButtonIcon icon={icon} size={size} />}
 
-			<ButtonText withIcon={!!icon}>{children}</ButtonText>
+			<ButtonText icon={!!icon} iconAlignment={iconAlignment}>
+				{children}
+			</ButtonText>
 
-			{iconAlignment === 'right' && (
-				<ButtonIcon icon={icon} iconAlignment={iconAlignment} size={size} />
-			)}
+			{iconAlignment === 'right' && <ButtonIcon icon={icon} size={size} />}
 		</ButtonContent>
 	</>
 )

--- a/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
+++ b/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import { ButtonColorTheme } from '../../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../../types/ComponentSize'
+import { left } from '../../../utils/rtl'
 
 export interface CommonStyledCheckboxRadioProps {
 	colorTheme: ButtonColorTheme
@@ -23,7 +24,7 @@ export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioPro
 		display: inline-block;
 		padding-top: ${({ size, theme }): string =>
 			`${(theme.$pc.checkboxRadio.size[size] - 16) / 2}px`};
-		padding-left: ${({ size, theme }): string =>
+		padding-inline-start: ${({ size, theme }): string =>
 			`${theme.$pc.checkboxRadio.size[size] + 8}px`};
 		min-height: ${({ size, theme }): string =>
 			`${theme.$pc.checkboxRadio.size[size]}px`};
@@ -45,7 +46,7 @@ export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioPro
 		border: 1px solid ${(props): string => props.theme.$pc.colors.borderInput};
 		background: #fff;
 		top: 0;
-		left: 0;
+		${left(0)}
 		transition: ${({ theme }): string =>
 			`box-shadow ${theme.$pc.transitionDuration}, background-color ${theme.$pc.transitionDuration}, border ${theme.$pc.transitionDuration}`};
 		box-shadow: 0 0 0 0 ${({ theme }): string => theme.$pc.colors.focus};

--- a/src/components/common/CheckboxRadio/index.tsx
+++ b/src/components/common/CheckboxRadio/index.tsx
@@ -7,6 +7,7 @@ import { Label } from './CheckboxRadioStyles'
 
 export interface CheckboxRadioCommonProps
 	extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
 	RTL?: boolean
 	colorTheme?: ButtonColorTheme
 	size?: ComponentSizeMediumLarge

--- a/src/components/common/FormControl/FormControlStyles.tsx
+++ b/src/components/common/FormControl/FormControlStyles.tsx
@@ -1,7 +1,12 @@
 import SVG from 'react-inlinesvg'
-import styled, { DefaultTheme } from 'styled-components'
+import styled, {
+	css,
+	DefaultTheme,
+	FlattenSimpleInterpolation
+} from 'styled-components'
 
 import { ComponentSize } from '../../../types/ComponentSize'
+import { left } from '../../../utils/rtl'
 
 const getHeight = (theme: DefaultTheme, size: ComponentSize): string =>
 	theme.$pc.formControl.height[size] + 'px'
@@ -29,7 +34,6 @@ interface LabelProps {
 	error?: boolean
 	filled?: boolean
 	disabled?: boolean
-	RTL?: boolean
 }
 
 export const Label = styled.label<LabelProps>`
@@ -50,29 +54,36 @@ export const Label = styled.label<LabelProps>`
 		return props.theme.$pc.colors.text.light
 	}};
 
-	${({ RTL }): string =>
-		RTL
-			? `
-		right: 0;
+	${left(0)}
+	transform-origin: top left;
+	[dir='rtl'] && {
 		transform-origin: top right;
-		`
-			: `
-		left: 0;
-		transform-origin: top left;
-	`};
+	}
 
-	transform: ${({ theme, focused, filled, size, RTL }): string =>
+	${({ theme, focused, filled, size }): FlattenSimpleInterpolation =>
 		focused || filled
-			? `
-		translate(${RTL ? '-' : ''}${
-					theme.$pc.formControl.paddingX
-			  }px, -6px) scale(0.857);
-	`
-			: `
-		translate(${RTL ? '-' : ''}${
-					theme.$pc.formControl.paddingX
-			  }px, ${getLabelTranslateY(theme, size)}px) scale(1);
-	`};
+			? css`
+					transform: translate(${theme.$pc.formControl.paddingX}px, -6px)
+						scale(0.857);
+					[dir='rtl'] && {
+						transform: translate(-${theme.$pc.formControl.paddingX}px, -6px)
+							scale(0.857);
+					}
+			  `
+			: css`
+					transform: translate(
+							${theme.$pc.formControl.paddingX}px,
+							${getLabelTranslateY(theme, size)}px
+						)
+						scale(1);
+					[dir='rtl'] && {
+						transform: translate(
+								-${theme.$pc.formControl.paddingX}px,
+								${getLabelTranslateY(theme, size)}px
+							)
+							scale(1);
+					}
+			  `};
 `
 
 /**
@@ -154,7 +165,6 @@ interface StyledInputAndTextAreaProps {
 	$size: ComponentSize
 	focused?: boolean
 	disabled?: boolean
-	RTL?: boolean
 }
 
 export const StyledInput = styled.input<StyledInputAndTextAreaProps>`
@@ -182,16 +192,11 @@ export const StyledSelectNative = styled.select<StyledInputAndTextAreaProps>`
 	${(props): string =>
 		getFormControlCommonStyles(props.theme, props.focused, props.disabled)}
 
-	${({ theme, $size, RTL }): string => {
-		const paddingX = theme.$pc.formControl.paddingX
-		const right = RTL ? paddingX : paddingX + 20
-		const left = RTL ? paddingX + 20 : paddingX
-
-		return `
-			height: ${getHeight(theme, $size)};
-			padding: 0 ${right}px 0 ${left}px;
-		`
-	}}
+	${({ theme, $size }): FlattenSimpleInterpolation => css`
+		height: ${getHeight(theme, $size)};
+		padding-inline-start: ${theme.$pc.formControl.paddingX}px;
+		padding-inline-end: ${theme.$pc.formControl.paddingX + 20}px;
+	`}
 	
 	appearance: none;
 `
@@ -242,7 +247,6 @@ export const Fieldset = styled.fieldset<FieldsetProps>`
 interface LegendProps {
 	focused?: boolean
 	filled?: boolean
-	RTL?: boolean
 	label?: string
 }
 
@@ -252,7 +256,7 @@ export const Legend = styled.legend<LegendProps>`
 	display: block;
 	padding: 0;
 	font-size: 12px;
-	text-align: ${({ RTL }): string => (RTL ? 'right' : 'left')};
+	text-align: start;
 	visibility: hidden;
 
 	${({ focused, filled, label }): string =>
@@ -268,8 +272,8 @@ export const Legend = styled.legend<LegendProps>`
 
 	span {
 		display: inline-block;
-		padding-left: 5px;
-		padding-right: 5px;
+		padding-inline-start: 5px;
+		padding-inline-end: 5px;
 	}
 `
 
@@ -304,15 +308,12 @@ export const HelperText = styled.div<HelperTextProps>`
 
 interface ContentRightProps {
 	size: ComponentSize
-	RTL?: boolean
 }
 
 export const ContentRight = styled.div<ContentRightProps>`
 	line-height: ${({ theme, size }): string => getHeight(theme, size)};
-	${({ theme, RTL }): string =>
-		RTL
-			? `padding-left: ${theme.$pc.formControl.paddingX}px;`
-			: `padding-right: ${theme.$pc.formControl.paddingX}px;`}
+	padding-inline-end: ${({ theme }): number =>
+		theme.$pc.formControl.paddingX}px;
 	color: ${({ theme }): string => theme.$pc.colors.text.light};
 `
 
@@ -322,14 +323,10 @@ export const ContentRight = styled.div<ContentRightProps>`
 
 interface CheckmarkProps {
 	$size: ComponentSize
-	$RTL?: boolean
 }
 
 export const Checkmark = styled(SVG)<CheckmarkProps>`
-	${({ theme, $RTL }): string =>
-		$RTL
-			? `margin-left: ${theme.$pc.formControl.paddingX}px;`
-			: `margin-right: ${theme.$pc.formControl.paddingX}px;`}
+	margin-inline-end: ${({ theme }): number => theme.$pc.formControl.paddingX}px;
 	/** Add 3px from the top so the checkmark icon is vertically centered to the text. */
 	margin-top: ${({ theme, $size }): string =>
 		`${getLabelTranslateY(theme, $size) + 3}`}px;

--- a/src/components/common/FormControl/index.tsx
+++ b/src/components/common/FormControl/index.tsx
@@ -28,6 +28,7 @@ export interface FormControlProps {
 	contentRight?: string | React.ReactNode
 	/** Helper text to display when input is focused */
 	helperText?: string
+	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
 	RTL?: boolean
 	size?: ComponentSize
 	className?: string
@@ -46,6 +47,7 @@ const FormControl: React.FC<FormControlInternalProps> = ({
 	error,
 	contentRight,
 	helperText,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	className,
 	disabled,
@@ -57,7 +59,7 @@ const FormControl: React.FC<FormControlInternalProps> = ({
 	const label = size !== 'tiny' ? props.label : undefined
 
 	return (
-		<Wrapper dir={RTL ? 'rtl' : 'ltr'} className={className}>
+		<Wrapper className={className}>
 			<Label
 				focused={focused}
 				warning={!!warning}
@@ -65,7 +67,6 @@ const FormControl: React.FC<FormControlInternalProps> = ({
 				filled={filled}
 				disabled={disabled}
 				size={size}
-				RTL={RTL}
 			>
 				{label}
 			</Label>
@@ -73,12 +74,10 @@ const FormControl: React.FC<FormControlInternalProps> = ({
 			<InputWrapper>
 				{props.children}
 
-				{success && <Checkmark $size={size} src={checkIcon} $RTL={RTL} />}
+				{success && <Checkmark $size={size} src={checkIcon} />}
 
 				{contentRight && (
-					<ContentRight size={size} RTL={RTL}>
-						{contentRight}
-					</ContentRight>
+					<ContentRight size={size}>{contentRight}</ContentRight>
 				)}
 
 				<Fieldset
@@ -89,7 +88,7 @@ const FormControl: React.FC<FormControlInternalProps> = ({
 					disabled={disabled}
 					size={size}
 				>
-					<Legend focused={focused} filled={filled} RTL={RTL} label={label}>
+					<Legend focused={focused} filled={filled} label={label}>
 						<span>{label}</span>
 					</Legend>
 				</Fieldset>

--- a/src/components/common/FormControlWarningError/FormControlWarningErrorStyles.tsx
+++ b/src/components/common/FormControlWarningError/FormControlWarningErrorStyles.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 import { ColorTheme } from '../../../types/ColorTheme'
+import { left } from '../../../utils/rtl'
 import { Icon } from '../../Icon'
 
 interface WarningErrorTextProps {
@@ -9,7 +10,10 @@ interface WarningErrorTextProps {
 
 export const WarningErrorText = styled.div<WarningErrorTextProps>`
 	position: relative;
-	padding: 7px 0 1px 28px;
+	padding-inline-start: 28px;
+	padding-inline-end: 0;
+	padding-top: 7px;
+	padding-bottom: 1px;
 	color: ${({ theme, colorTheme }): string =>
 		theme.$pc.colors[colorTheme].dark};
 	font-size: 12px;
@@ -19,5 +23,5 @@ export const WarningErrorText = styled.div<WarningErrorTextProps>`
 export const StyledIcon = styled(Icon)`
 	position: absolute;
 	top: 6px;
-	left: 5px;
+	${left('5px')}
 `

--- a/src/components/common/Select/SelectStyles.tsx
+++ b/src/components/common/Select/SelectStyles.tsx
@@ -20,8 +20,7 @@ export const StyledSelect = styled(ReactSelect)<StyledSelectProps>`
 `
 export const getStyles = (
 	theme: DefaultTheme,
-	size: ComponentSize,
-	RTL?: boolean
+	size: ComponentSize
 ): StylesConfig<SelectOption, false> => ({
 	control: (provided): CSSObject => ({
 		...provided,
@@ -44,17 +43,11 @@ export const getStyles = (
 	}),
 
 	/** Dropdown arrow */
-	dropdownIndicator: (provided, state): CSSObject => {
-		const padding = RTL
-			? `0 0 0 ${theme.$pc.formControl.paddingX}px`
-			: `0 ${theme.$pc.formControl.paddingX}px 0 0`
-
-		return {
-			...provided,
-			opacity: state.isDisabled ? 0.3 : 1,
-			padding
-		}
-	},
+	dropdownIndicator: (provided, state): CSSObject => ({
+		...provided,
+		opacity: state.isDisabled ? 0.3 : 1,
+		paddingInlineEnd: theme.$pc.formControl.paddingX
+	}),
 
 	/** Dropdown popover */
 	menu: (provided): CSSObject => ({
@@ -108,8 +101,8 @@ export const getStyles = (
 	multiValueLabel: (provided): CSSObject => ({
 		...provided,
 		paddingTop: `${theme.$pc.multiSelect.multiValueLabel.paddingY[size]}px`,
-		paddingLeft: `${theme.$pc.multiSelect.multiValueLabel.paddingX[size]}px`,
-		paddingRight: 0,
+		paddingInlineStart: `${theme.$pc.multiSelect.multiValueLabel.paddingX[size]}px`,
+		paddingInlineEnd: 0,
 		paddingBottom: `${theme.$pc.multiSelect.multiValueLabel.paddingY[size]}px`,
 		fontSize: `${theme.$pc.multiSelect.multiValueLabel.fontSize[size]}px`
 	}),

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -55,7 +55,7 @@ const CommonSelect: React.FC<InternalCommonSelectProps> = ({
 		useFormControl<HTMLSelectElement>(props.onFocus, props.onBlur)
 
 	const theme = useContext(ThemeContext)
-	const styles = getStyles(theme, size, props.RTL)
+	const styles = getStyles(theme, size)
 
 	const isFilled =
 		(Array.isArray(props.value) && props.value.length > 0) ||
@@ -68,7 +68,6 @@ const CommonSelect: React.FC<InternalCommonSelectProps> = ({
 			warning={props.warning}
 			error={props.error}
 			contentRight={props.contentRight}
-			RTL={props.RTL}
 			className={props.className}
 			size={size}
 			disabled={props.disabled}
@@ -84,7 +83,6 @@ const CommonSelect: React.FC<InternalCommonSelectProps> = ({
 				isDisabled={props.disabled}
 				isSearchable={!props.preventSearch}
 				placeholder=""
-				isRtl={props.RTL}
 				options={props.options}
 				name={props.name}
 				value={props.value}

--- a/src/components/common/Spacing/SpacingStyles.tsx
+++ b/src/components/common/Spacing/SpacingStyles.tsx
@@ -1,4 +1,8 @@
-import { css, DefaultTheme } from 'styled-components'
+import {
+	css,
+	DefaultTheme,
+	FlattenSimpleInterpolation
+} from 'styled-components'
 
 import { Spacing } from '../../../types/Spacing'
 import { MarginProps } from '../../common/Spacing/MarginProps'
@@ -32,21 +36,31 @@ const getSpacing = (
 }
 
 export const paddingCss = css<PaddingProps>`
-	${({ theme, pt, pb, pl, pr, px, py, p }): string => {
+	${({ theme, pt, pb, pl, pr, px, py, p }): FlattenSimpleInterpolation => {
 		const top = getSpacing(theme, pt, py, p)
 		const right = getSpacing(theme, pr, px, p)
 		const bottom = getSpacing(theme, pb, py, p)
 		const left = getSpacing(theme, pl, px, p)
-		return `padding: ${top} ${right} ${bottom} ${left};`
+		return css`
+			padding-top: ${top};
+			padding-bottom: ${bottom};
+			padding-inline-start: ${left};
+			padding-inline-end: ${right};
+		`
 	}}
 `
 
 export const marginCss = css<MarginProps>`
-	${({ theme, mt, mb, ml, mr, mx, my, m }): string => {
+	${({ theme, mt, mb, ml, mr, mx, my, m }): FlattenSimpleInterpolation => {
 		const top = getSpacing(theme, mt, my, m)
 		const right = getSpacing(theme, mr, mx, m)
 		const bottom = getSpacing(theme, mb, my, m)
 		const left = getSpacing(theme, ml, mx, m)
-		return `margin: ${top} ${right} ${bottom} ${left};`
+		return css`
+			margin-top: ${top};
+			margin-bottom: ${bottom};
+			margin-inline-start: ${left};
+			margin-inline-end: ${right};
+		`
 	}}
 `

--- a/src/components/common/Text/TextStyles.tsx
+++ b/src/components/common/Text/TextStyles.tsx
@@ -6,7 +6,7 @@ import { TextColor } from '../../../types/TextColor'
 import { marginCss, paddingCss } from '../Spacing/SpacingStyles'
 
 export interface StyledTextParagraphProps {
-	$size: ComponentSizeSmallMediumLarge | string
+	$size: ComponentSizeSmallMediumLarge | string | number
 	$color: TextColor
 	colorTheme?: ColorTheme
 	bold?: boolean
@@ -18,6 +18,8 @@ export const commonTextStyles = css<StyledTextParagraphProps>`
 			$size as ComponentSizeSmallMediumLarge
 		)
 			? `${theme.$pc.text.size[$size as ComponentSizeSmallMediumLarge]}px`
+			: typeof $size === 'number'
+			? `${$size}px`
 			: $size};
 	font-weight: ${({ bold }): number => (bold ? 500 : 400)};
 	${({ colorTheme, $color, theme }): string => {

--- a/src/demo/DemoForm/DemoFormStyle.tsx
+++ b/src/demo/DemoForm/DemoFormStyle.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 export const FormStyled = styled.form`
-	max-width: 50%;
+	max-width: 400px;
 
 	margin: 0 auto;
 

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -1,0 +1,44 @@
+import {
+	css,
+	DefaultTheme,
+	FlattenInterpolation,
+	FlattenSimpleInterpolation,
+	ThemeProps
+} from 'styled-components'
+
+const leftOrRight = (
+	mainDirection: 'left' | 'right',
+	offset: string | number
+): FlattenInterpolation<ThemeProps<DefaultTheme>> => css`
+	${({ theme }): FlattenSimpleInterpolation => {
+		const rtlDirection = mainDirection === 'left' ? 'right' : 'left'
+
+		if (theme.dir && ['ltr', 'rtl'].includes(theme.dir)) {
+			if (theme.dir === 'rtl') {
+				return css`
+					${rtlDirection}: ${offset};
+				`
+			}
+			return css`
+				${mainDirection}: ${offset};
+			`
+		}
+
+		return css`
+			${mainDirection}: ${offset};
+			[dir='rtl'] & {
+				${mainDirection}: initial;
+				${rtlDirection}: ${offset};
+			}
+		`
+	}}
+`
+
+export const left = (
+	offset: string | number
+): FlattenInterpolation<ThemeProps<DefaultTheme>> => leftOrRight('left', offset)
+
+export const right = (
+	offset: string | number
+): FlattenInterpolation<ThemeProps<DefaultTheme>> =>
+	leftOrRight('right', offset)

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -6,5 +6,7 @@ import { Theme } from './src/theme'
 // and extend them!
 declare module 'styled-components' {
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface
-	export interface DefaultTheme extends Theme {}
+	export interface DefaultTheme extends Theme {
+		dir: 'ltr' | 'rtl'
+	}
 }


### PR DESCRIPTION
Phoenix components newly get use of CSS logical properties, such as `padding-inline-start`, instead of `padding-left`, `margin-inline-end` instead of `margin-right` or `text-align: start;` instead of `text-align: left;` etc. to better support RTL layouts. I checked that support across browsers is on a production level. Shorthand properties such as `padding-inline` or `margin-inline` cannot be used though due to missing support in the previous (still largely used) version of Safari and Safari for iOS.

Also, CSS logical equivalents for properties `left` and `right` are not production ready. Instead, I created helper functions generating CSS relying on `[dir="rtl"]` somewhere higher in DOM tree. This is necessary to include for RTL layouts anyway so I just get use of it.  This extra generated CSS (which is not many TBH) can be elegantly removed by including `dir` key in styled-components theme (as described in README file).

With these changes, I realized `RTL` props in all the components are redundant and has been marked as deprecated.

Other improvements:

- RTL plugin to Storybook for easy LTR/RTL switching
- ClosableItem component uses Close component from ClosableButton component (removed duplicate)
- Heading, Text and Paragraph components support number type for size (treated as pixels)
- Button component - fixed spacing in a version with icon only (no text)