### PR TITLE
feat(Link): new props

### DIFF
--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,6 +1,7 @@
 import { Story } from '@storybook/react'
 import React, { PropsWithChildren } from 'react'
 
+import { ColorTheme } from '../../types/ColorTheme'
 import { IconAlignment } from '../../types/IconAlignment'
 import { PhoenixIconsOutlined } from '../../types/PhoenixIcons'
 import { Link as LinkComponent, LinkProps } from './index'
@@ -15,6 +16,9 @@ export default {
 		iconAlignment: {
 			options: IconAlignment,
 			defaultValue: 'left'
+		},
+		colorTheme: {
+			options: [undefined, ...ColorTheme]
 		}
 	}
 }

--- a/src/components/Link/LinkIcon.tsx
+++ b/src/components/Link/LinkIcon.tsx
@@ -1,31 +1,31 @@
 import React from 'react'
 
-import { IconAlignment } from '../../types/IconAlignment'
+import { ColorTheme } from '../../types/ColorTheme'
 import { IconType } from '../../types/IconType'
+import { TextColor } from '../../types/TextColor'
 import { isPhoenixIconOutlined } from '../../utils/icons'
 import { StyledCustomIcon, StyledIcon } from './LinkStyles'
 
 interface IconProps {
 	icon?: IconType
-	iconAlignment?: IconAlignment
+	colorTheme?: ColorTheme
+	color?: TextColor
 }
 
-const LinkIcon: React.FC<IconProps> = (props) => {
-	if (!props.icon || !props.iconAlignment) {
+const LinkIcon: React.FC<IconProps> = ({ icon, colorTheme, color }) => {
+	if (!icon) {
 		return null
 	}
 
-	if (isPhoenixIconOutlined(props.icon)) {
-		return <StyledIcon icon={props.icon} $iconAlignment={props.iconAlignment} />
+	if (isPhoenixIconOutlined(icon)) {
+		return <StyledIcon icon={icon} color={color} colorTheme={colorTheme} />
 	}
 
-	if (typeof props.icon === 'string') {
-		return (
-			<StyledCustomIcon src={props.icon} $iconAlignment={props.iconAlignment} />
-		)
+	if (typeof icon === 'string') {
+		return <StyledCustomIcon src={icon} color={color} colorTheme={colorTheme} />
 	}
 
-	return props.icon
+	return icon
 }
 
 export default LinkIcon

--- a/src/components/Link/LinkStyles.tsx
+++ b/src/components/Link/LinkStyles.tsx
@@ -1,35 +1,59 @@
 import SVG from 'react-inlinesvg'
-import styled, { css } from 'styled-components'
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 
+import { TextColor } from '../..'
+import { ColorTheme } from '../../types/ColorTheme'
 import { IconAlignment } from '../../types/IconAlignment'
+import { marginCss, paddingCss } from '../common/Spacing/SpacingStyles'
 import { Icon } from '../Icon'
 
-export const StyledLink = styled.a`
-	text-decoration: underline;
-	color: ${({ theme }): string => theme.$pc.colors.primary.dark};
+interface StyledLinkProps {
+	colorTheme?: ColorTheme
+	$color?: TextColor
+	bold?: boolean
+	noUnderline?: boolean
+}
+
+export const StyledLink = styled.a<StyledLinkProps>`
+	text-decoration: ${({ noUnderline }): string =>
+		noUnderline ? ' none' : 'underline'};
+	color: ${({ colorTheme, $color, theme }): string =>
+		colorTheme
+			? theme.$pc.colors[colorTheme].dark
+			: $color
+			? theme.$pc.colors.text[$color]
+			: theme.$pc.colors.primary.dark};
 	cursor: pointer;
+	${({ bold }): string => (bold ? 'font-weight: 500;' : '')}
+
 	&:hover,
 	&:active,
 	&:focus {
-		text-decoration: none;
+		text-decoration: ${({ noUnderline }): string =>
+			noUnderline ? 'underline' : 'none'};
 	}
+
+	${marginCss}
+	${paddingCss}
 `
 
-interface StyledIconProps {
-	$iconAlignment: IconAlignment
+interface StyledIconCssProps {
+	colorTheme?: ColorTheme
+	color?: TextColor
 }
 
-export const styledIconCss = css<StyledIconProps>`
+export const styledIconCss = css<StyledIconCssProps>`
 	path {
-		fill: ${({ theme }): string => theme.$pc.colors.primary.dark};
+		fill: ${({ colorTheme, color, theme }): string =>
+			colorTheme
+				? theme.$pc.colors[colorTheme].dark
+				: color
+				? theme.$pc.colors.text[color]
+				: theme.$pc.colors.primary.dark};
 	}
 	width: 1em;
 	height: 1em;
 	vertical-align: -0.15em;
-	${({ $iconAlignment }): string =>
-		$iconAlignment === 'left'
-			? 'margin-inline-end: .4em;'
-			: 'margin-inline-start: .4em;'}
 `
 
 export const StyledCustomIcon = styled(SVG)`
@@ -38,4 +62,26 @@ export const StyledCustomIcon = styled(SVG)`
 
 export const StyledIcon = styled(Icon)`
 	${styledIconCss}
+`
+
+interface LinkTextProps {
+	icon?: boolean
+	iconAlignment?: IconAlignment
+}
+
+export const LinkText = styled.span<LinkTextProps>`
+	${({
+		children,
+		icon,
+		iconAlignment
+	}): FlattenSimpleInterpolation | undefined =>
+		children && icon
+			? iconAlignment === 'left'
+				? css`
+						margin-inline-start: 0.4em;
+				  `
+				: css`
+						margin-inline-end: 0.4em;
+				  `
+			: undefined}
 `

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,16 +1,26 @@
 import React, { forwardRef } from 'react'
 
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
+import { ColorTheme } from '../../types/ColorTheme'
 import { IconAlignment } from '../../types/IconAlignment'
 import { IconType } from '../../types/IconType'
+import { TextColor } from '../../types/TextColor'
+import { MarginProps } from '../common/Spacing/MarginProps'
+import { PaddingProps } from '../common/Spacing/PaddingProps'
 import LinkIcon from './LinkIcon'
-import { StyledLink } from './LinkStyles'
+import { LinkText, StyledLink } from './LinkStyles'
 
 export interface LinkProps
 	extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
-		GenericComponentProps {
+		GenericComponentProps,
+		MarginProps,
+		PaddingProps {
 	icon?: IconType
 	iconAlignment?: IconAlignment
+	colorTheme?: ColorTheme
+	color?: TextColor
+	bold?: boolean
+	noUnderline?: boolean
 }
 
 /**
@@ -19,19 +29,21 @@ export interface LinkProps
 export const Link: React.ForwardRefExoticComponent<
 	React.PropsWithoutRef<LinkProps> & React.RefAttributes<HTMLAnchorElement>
 > = forwardRef(function Link(
-	{ testId = 'Link', children, icon, iconAlignment = 'left', ...props },
+	{ testId = 'Link', children, icon, iconAlignment = 'left', color, ...props },
 	ref
 ) {
 	return (
-		<StyledLink ref={ref} data-testid={testId} {...props}>
+		<StyledLink ref={ref} data-testid={testId} $color={color} {...props}>
 			{iconAlignment === 'left' && (
-				<LinkIcon icon={icon} iconAlignment={iconAlignment} />
+				<LinkIcon icon={icon} color={color} colorTheme={props.colorTheme} />
 			)}
 
-			{children}
+			<LinkText icon={!!icon} iconAlignment={iconAlignment}>
+				{children}
+			</LinkText>
 
 			{iconAlignment === 'right' && (
-				<LinkIcon icon={icon} iconAlignment={iconAlignment} />
+				<LinkIcon icon={icon} color={color} colorTheme={props.colorTheme} />
 			)}
 		</StyledLink>
 	)


### PR DESCRIPTION
Several new props added to Link component:

- `colorTheme`
- `color`
- `noUnderline`
- `bold`
- margin and padding props

Plus one extra small change. Margin was moved from icon to inner text span so that whenever there's a link with only icon, there's no unnecessary space. It could have stayed at icon component but props would have to be drilled more levels down. It's also done this way in common/Button component so it's consistent.