### PR TITLE
fix(Box): fix in styling related to styled-system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.17.1](https://github.com/purple-technology/phoenix-components/compare/v4.17.0...v4.17.1) (2021-11-03)
+
+
+### Bug Fixes
+
+* **Box:** fix in styling related to styled-system ([ca7fdeb](https://github.com/purple-technology/phoenix-components/commit/ca7fdeb47aadecd5df3090476c3e5963643c685c))
+
 ## [4.17.0](https://github.com/purple-technology/phoenix-components/compare/v4.16.0...v4.17.0) (2021-11-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.17.0",
+	"version": "4.17.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.17.0",
+	"version": "4.17.1",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/Box/Box.stories.mdx
+++ b/src/components/Box/Box.stories.mdx
@@ -16,15 +16,14 @@ Most abstract layout component for applying simple styling.
 
 By default, it's rendered as `<div>` (this can be overridden by an `element` prop), and it accepts following groups of props:
 
-- <LinkTo kind="docs-margin-padding--page">margin & padding</LinkTo>
+- <LinkTo kind="Docs / Margin & Padding">margin & padding</LinkTo>
 - <a href="https://styled-system.com/table#layout" target="_blank">layout</a>
 - <a href="https://styled-system.com/table#flexbox" target="_blank">flexbox</a>
 - <a href="https://styled-system.com/table#grid" target="_blank">grid</a>
 - <a href="https://styled-system.com/table#background" target="_blank">background</a>
 - <a href="https://styled-system.com/table#position" target="_blank">position</a>
-- `backgroundColor`
+- <a href="https://styled-system.com/table#color" target="_blank">color</a>
 - `textAlign`
-- `opacity`
 
 **NOTE: It is important not to overuse this component! Please allow maximum of around 6 props and then consider using dedicated styled component.**
 

--- a/src/components/Box/BoxStyles.tsx
+++ b/src/components/Box/BoxStyles.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components'
 import {
 	background,
-	backgroundColor,
+	color,
 	flexbox,
 	grid,
 	layout,
-	opacity,
 	position
 } from 'styled-system'
 
@@ -17,8 +16,7 @@ export const StyledBox = styled.div`
 	${flexbox}
 	${grid}
 	${background}
-	${backgroundColor}
-	${opacity}
+	${color}
 	${position}
 	${marginCss}
 	${paddingCss}

--- a/src/components/Flex/Flex.stories.mdx
+++ b/src/components/Flex/Flex.stories.mdx
@@ -12,7 +12,7 @@ import { Flex } from '.'
 
 # Flex
 
-Flex is a <LinkTo kind="components-layout-box--page">Box</LinkTo> component with `display` set to `flex` (can be overridden for example to `inline-flex`).
+Flex is a <LinkTo kind="components / Box">Box</LinkTo> component with `display` set to `flex` (can be overridden for example to `inline-flex`).
 
 <Canvas withSource="open">
     <Story name="Flex">

--- a/src/components/Grid/Grid.stories.mdx
+++ b/src/components/Grid/Grid.stories.mdx
@@ -12,7 +12,7 @@ import { Grid } from '.'
 
 # Grid
 
-Grid is a <LinkTo kind="components-layout-box--page">Box</LinkTo> component with `display` set to `grid` (can be overridden for example to `inline-grid`).
+Grid is a <LinkTo kind="components / Box">Box</LinkTo> component with `display` set to `grid` (can be overridden for example to `inline-grid`).
 
 <Canvas withSource="open">
     <Story name="Grid">


### PR DESCRIPTION
- removed `backgroundColor` (not exported by the package) and `opacity` and replaced by `color` which includes `backgroundColor`, `color` and `opacity` (https://styled-system.com/table#color)
- fixed docs