### PR TITLE
ci: add commit linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,11 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Run Linter
+          name: Run Commit Linter
+          # The commit hash since when the history is checked
+          command: npx commitlint --from ecee82ff287af77f21a3f42b2b80a1d96124b1e3 --to HEAD
+      - run:
+          name: Run Code Linter
           command: npm run lint
       - run:
           name: Run Tests


### PR DESCRIPTION
Add commit linting also to CI.

I have picked the last commit (https://github.com/purple-technology/phoenix-components/commit/ecee82ff287af77f21a3f42b2b80a1d96124b1e3) as a reference point since when all the commits will be checked. Because otherwise it checked the whole history which obviously failed because we didn't use conventional commits from the beginning.

Jira task: https://purpletechnology.atlassian.net/browse/PUST-74