### PR TITLE
Modal and checkbox/radio improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.21.0](https://github.com/purple-technology/phoenix-components/compare/v4.20.2...v4.21.0) (2022-01-19)
+
+
+### Features
+
+* checkbox and radio components - error state ([139761b](https://github.com/purple-technology/phoenix-components/commit/139761be4348f45b7a3882f0073241ea450aa795))
+* **Modal:** added prop closeOnOverlayClick ([c48383f](https://github.com/purple-technology/phoenix-components/commit/c48383fdcc69eb45a88ace46e9ac2b399b034cc5))
+
 ### [4.20.2](https://github.com/purple-technology/phoenix-components/compare/v4.20.1...v4.20.2) (2022-01-18)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.20.2",
+	"version": "4.21.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.20.2",
+	"version": "4.21.0",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { CheckboxRadioCommonProps } from '../common/CheckboxRadio'
 import CheckboxRadio from '../common/CheckboxRadio'
+import FormControlWarningError from '../common/FormControlWarningError'
 import { StyledCheckbox } from './CheckboxStyles'
 
 export type CheckboxProps = CheckboxRadioCommonProps
@@ -13,17 +14,24 @@ export const Checkbox: React.VoidFunctionComponent<CheckboxProps> = ({
 	size = 'medium',
 	colorTheme = 'primary',
 	className,
+	warning,
+	error,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	testId = 'Checkbox',
 	...props
 }) => (
-	<StyledCheckbox
-		className={className}
-		colorTheme={colorTheme}
-		size={size}
-		data-testid={testId}
-	>
-		<CheckboxRadio type="checkbox" {...props} />
-	</StyledCheckbox>
+	<>
+		<StyledCheckbox
+			className={className}
+			colorTheme={colorTheme}
+			size={size}
+			data-testid={testId}
+			warning={!!warning}
+			error={!!error}
+		>
+			<CheckboxRadio type="checkbox" {...props} />
+		</StyledCheckbox>
+		<FormControlWarningError warning={warning} error={error} />
+	</>
 )

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { Button } from '../Button'
 import { Heading } from '../Heading'
@@ -12,7 +12,11 @@ export default {
 } as ComponentMeta<typeof ModalComponent>
 
 export const Modal: ComponentStory<typeof ModalComponent> = (args) => {
-	const [open, setOpen] = useState(false)
+	const [open, setOpen] = useState(args.open)
+
+	useEffect(() => {
+		setOpen(args.open)
+	}, [args.open])
 
 	return (
 		<>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -11,11 +11,12 @@ export interface ModalProps
 		PaddingProps,
 		MarginProps {
 	open: boolean
-	onClose: () => void
+	onClose?: () => void
 	showCloseButton?: boolean
 	size?: ComponentSize
 	animate?: boolean
 	center?: boolean
+	closeOnOverlayClick?: boolean
 }
 
 export const Modal: React.FC<ModalProps> = ({
@@ -24,6 +25,7 @@ export const Modal: React.FC<ModalProps> = ({
 	center = true,
 	animate = true,
 	showCloseButton = true,
+	closeOnOverlayClick = true,
 	open,
 	onClose,
 	children,
@@ -34,9 +36,11 @@ export const Modal: React.FC<ModalProps> = ({
 	const windowRef = useRef<HTMLDivElement>(null)
 
 	const onOverlayClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
-		e.preventDefault()
-
-		if (!windowRef.current?.contains(e.target as HTMLElement)) {
+		if (
+			!windowRef.current?.contains(e.target as HTMLElement) &&
+			onClose &&
+			closeOnOverlayClick
+		) {
 			onClose()
 		}
 	}
@@ -54,7 +58,7 @@ export const Modal: React.FC<ModalProps> = ({
 
 	useEffect(() => {
 		if (rendered) {
-			setImmediate(() => setVisible(true))
+			setTimeout(() => setVisible(true), 1)
 		}
 	}, [rendered])
 

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { CheckboxRadioCommonProps } from '../common/CheckboxRadio'
 import CheckboxRadio from '../common/CheckboxRadio'
+import FormControlWarningError from '../common/FormControlWarningError'
 import { StyledRadio } from './RadioStyles'
 
 export type RadioProps = CheckboxRadioCommonProps
@@ -13,17 +14,24 @@ export const Radio: React.VoidFunctionComponent<RadioProps> = ({
 	size = 'medium',
 	colorTheme = 'primary',
 	className,
+	warning,
+	error,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	RTL,
 	testId = 'Radio',
 	...props
 }) => (
-	<StyledRadio
-		className={className}
-		colorTheme={colorTheme}
-		size={size}
-		data-testid={testId}
-	>
-		<CheckboxRadio type="radio" {...props} />
-	</StyledRadio>
+	<>
+		<StyledRadio
+			className={className}
+			colorTheme={colorTheme}
+			size={size}
+			data-testid={testId}
+			warning={!!warning}
+			error={!!error}
+		>
+			<CheckboxRadio type="radio" {...props} />
+		</StyledRadio>
+		<FormControlWarningError warning={warning} error={error} />
+	</>
 )

--- a/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
+++ b/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { DefaultTheme } from 'styled-components'
 
 import { ButtonColorTheme } from '../../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../../types/ComponentSize'
@@ -7,6 +7,25 @@ import { left } from '../../../utils/rtl'
 export interface CommonStyledCheckboxRadioProps {
 	colorTheme: ButtonColorTheme
 	size: ComponentSizeMediumLarge
+	/** Show yellow warning text and icon under the input */
+	warning?: boolean
+	/** Show red error text and icon under the input */
+	error?: boolean
+}
+
+const getColor = (
+	theme: DefaultTheme,
+	warning?: boolean,
+	error?: boolean,
+	defaultColor?: string
+): string | undefined => {
+	if (error) {
+		return theme.$pc.colors['error'].dark
+	} else if (warning) {
+		return theme.$pc.colors['warning'].dark
+	}
+
+	return defaultColor
 }
 
 export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioProps>`
@@ -29,6 +48,8 @@ export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioPro
 		min-height: ${({ size, theme }): string =>
 			`${theme.$pc.checkboxRadio.size[size]}px`};
 		user-select: none;
+		color: ${({ theme, warning, error }): string | undefined =>
+			getColor(theme, warning, error)};
 	}
 
 	label::before,
@@ -43,7 +64,9 @@ export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioPro
 			`${theme.$pc.checkboxRadio.size[size]}px`};
 		width: ${({ size, theme }): string =>
 			`${theme.$pc.checkboxRadio.size[size]}px`};
-		border: 1px solid ${(props): string => props.theme.$pc.colors.borderInput};
+		border: 1px solid
+			${({ theme, warning, error }): string | undefined =>
+				getColor(theme, warning, error, theme.$pc.colors.borderInput)};
 		background: #fff;
 		top: 0;
 		${left(0)}

--- a/src/components/common/CheckboxRadio/index.tsx
+++ b/src/components/common/CheckboxRadio/index.tsx
@@ -4,6 +4,10 @@ import React, { InputHTMLAttributes } from 'react'
 import { GenericComponentProps } from '../../../interfaces/GenericComponentProps'
 import { ButtonColorTheme } from '../../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../../types/ComponentSize'
+import {
+	FormControlErrorType,
+	FormControlWarningType
+} from '../FormControl/types'
 import { Label } from './CheckboxRadioStyles'
 
 export interface CheckboxRadioCommonProps
@@ -14,6 +18,10 @@ export interface CheckboxRadioCommonProps
 	colorTheme?: ButtonColorTheme
 	size?: ComponentSizeMediumLarge
 	label?: React.ReactNode
+	/** Show yellow warning text and icon under the input */
+	warning?: FormControlWarningType
+	/** Show red error text and icon under the input */
+	error?: FormControlErrorType
 }
 
 interface CheckboxRadioProps extends InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/common/CheckboxRadio/stories.tsx
+++ b/src/components/common/CheckboxRadio/stories.tsx
@@ -1,6 +1,17 @@
 import { ButtonColorTheme } from '../../../types/ColorTheme'
 
 export const argTypes = {
+	/** Prop error was by default JSON but we need text. */
+	error: {
+		control: 'text'
+	},
+	/** Prop warning was by default JSON but we need text. */
+	warning: {
+		control: 'text'
+	},
+	label: {
+		control: 'text'
+	},
 	size: {
 		options: ['medium', 'large'],
 		defaultValue: 'medium'


### PR DESCRIPTION
- Modal component - added prop `closeOnOverlayClick`
- Modal component - `onClose` made optional
- Modal component - removed `preventDefault` from `onOverlayClick` - prevented any clicks inside Modal (for example on Buttons)
- `error` and `warning` props added to Checkbox and Radio components and relevant styling introduced