### PR TITLE
fix(NumberInput): prevent input from clearing on invalid value

### DIFF
--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -75,8 +75,10 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 
 	useEffect(() => {
 		if (value === null) {
-			setTextValue('')
-			setInternalError(undefined)
+			if (!focused) {
+				setTextValue('')
+				setInternalError(undefined)
+			}
 		} else {
 			const { stringValue } = getSanitizedValue(
 				value?.toString() || '0',


### PR DESCRIPTION
At the moment, when the user first enters a valid number and then enters something, which will make the value invalid, the input is cleared. We want to allow the user to correct the error, so we do not clear it when focused.