### PR TITLE
fix(NumberInput): pass other htmlinput props to the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.23.2](https://github.com/purple-technology/phoenix-components/compare/v4.23.1...v4.23.2) (2022-02-21)
+
+
+### Bug Fixes
+
+* **NumberInput:** pass other htmlinput props to the input ([849fc06](https://github.com/purple-technology/phoenix-components/commit/849fc066b4d922742e20a38452eb86b6f54c339f))
+
 ### [4.23.1](https://github.com/purple-technology/phoenix-components/compare/v4.23.0...v4.23.1) (2022-02-18)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.1",
+	"version": "4.23.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.1",
+	"version": "4.23.2",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -108,6 +108,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 			testId={testId}
 		>
 			<StyledInput
+				{...props}
 				onChange={(e): void => setTextValue(e.target.value)}
 				type="text"
 				onFocus={thisOnFocus}


### PR DESCRIPTION
The other common props from HTMLInputElement are not passed to the inner input, which causes problems with Formik integration (namely that `name`) is not set.