### PR TITLE
fix(NumberInput): do not display success tick when internal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.23.4](https://github.com/purple-technology/phoenix-components/compare/v4.23.3...v4.23.4) (2022-03-15)
+
+
+### Bug Fixes
+
+* **NumberInput:** do not display success tick when internal error ([6ae217c](https://github.com/purple-technology/phoenix-components/commit/6ae217c79704de706565002b704e3e689783944e))
+
 ### [4.23.3](https://github.com/purple-technology/phoenix-components/compare/v4.23.2...v4.23.3) (2022-03-01)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.3",
+	"version": "4.23.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.3",
+	"version": "4.23.4",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -97,7 +97,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 	return (
 		<FormControl
 			label={label}
-			success={success}
+			success={!internalError && success}
 			warning={warning}
 			error={internalError ?? error}
 			contentRight={contentRight}


### PR DESCRIPTION
At the moment, when the component has an internal error (wrong number format), it still displays the success tick, if it has the success prop set to true.