### PR TITLE
fix: box-sizing border-box in checkbox and radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.23.5](https://github.com/purple-technology/phoenix-components/compare/v4.23.4...v4.23.5) (2022-03-15)
+
+
+### Bug Fixes
+
+* box-sizing border-box in checkbox and radio ([4c8bd1d](https://github.com/purple-technology/phoenix-components/commit/4c8bd1da860816d17e403c501f6327cf263601c5))
+
 ### [4.23.4](https://github.com/purple-technology/phoenix-components/compare/v4.23.3...v4.23.4) (2022-03-15)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.4",
+	"version": "4.23.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.23.4",
+	"version": "4.23.5",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
+++ b/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
@@ -73,6 +73,7 @@ export const CommonStyledCheckboxRadio = styled.div<CommonStyledCheckboxRadioPro
 		transition: ${({ theme }): string =>
 			`box-shadow ${theme.$pc.transitionDuration}, background-color ${theme.$pc.transitionDuration}, border ${theme.$pc.transitionDuration}`};
 		box-shadow: 0 0 0 0 ${({ theme }): string => theme.$pc.colors.focus};
+		box-sizing: border-box;
 	}
 
 	label::after {


### PR DESCRIPTION
We have `box-sizing: border-box;` defined globally in `GlobalStyles` component and this component must be used in the app. However, these global styles are somehow loaded a bit later than the component itself (at least I noticed this in MyAxiory). The result is that Checkbox and Radio components in checked state are rendered incorrectly for a split of second on load - see the screenshot. (Because the default value is `content-box` and in the case of Checkbox and Radio components we're directly using the inherent behaviour of `border-box` - keeping the same size regardless of border width)

<img width="793" alt="Screenshot 2022-03-15 at 12 58 23" src="https://user-images.githubusercontent.com/4357381/158374430-e33c46c3-4c35-4bc6-a29e-f494c473c9f0.png">

