### PR TITLE
fix(selectpicker): use standard way to render error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.24.1](https://github.com/purple-technology/phoenix-components/compare/v4.24.0...v4.24.1) (2022-04-20)
+
+
+### Bug Fixes
+
+* **selectpicker:** use standard way to render error ([fb0a9f3](https://github.com/purple-technology/phoenix-components/commit/fb0a9f31ede6e9f74e368cac43b2379bcc842646))
+
 ## [4.24.0](https://github.com/purple-technology/phoenix-components/compare/v4.23.5...v4.24.0) (2022-03-18)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.24.0",
+	"version": "4.24.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.24.0",
+	"version": "4.24.1",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/SelectPicker/index.tsx
+++ b/src/components/SelectPicker/index.tsx
@@ -3,9 +3,9 @@ import React, { useEffect, useState } from 'react'
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
 import { ButtonColorTheme } from '../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../types/ComponentSize'
+import FormControlWarningError from '../common/FormControlWarningError'
 import {
 	Checkbox,
-	Error,
 	Flex,
 	Option,
 	OptionDescription,
@@ -21,6 +21,7 @@ export interface SelectPickerProps extends GenericComponentProps {
 	name?: string
 	multiSelect?: boolean
 	error?: string | boolean
+	warning?: string
 	onMouseOver?: (event: React.MouseEvent) => void
 	onMouseLeave?: (event: React.MouseEvent) => void
 	colorTheme?: ButtonColorTheme
@@ -49,6 +50,7 @@ export const SelectPicker: React.FC<SelectPickerProps> = ({
 	onChange,
 	value,
 	error,
+	warning,
 	onMouseOver,
 	onMouseLeave,
 	className
@@ -166,7 +168,7 @@ export const SelectPicker: React.FC<SelectPickerProps> = ({
 			>
 				{getOptions(options)}
 			</Wrapper>
-			{error && <Error>{error}</Error>}
+			<FormControlWarningError warning={warning} error={error} />
 		</div>
 	)
 }


### PR DESCRIPTION
The error does not include the usual warning triangle. This fixes it.
Before
<img width="955" alt="image" src="https://user-images.githubusercontent.com/98832381/163459321-f286226a-2cbf-4a28-929a-9487eac45e0c.png">

After
<img width="955" alt="image" src="https://user-images.githubusercontent.com/98832381/163459144-675aad9b-08d8-407f-994b-b98ef4161dfb.png">
