### PR TITLE
fix(SelectNative): empty option for undefined value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.27.2](https://github.com/purple-technology/phoenix-components/compare/v4.27.1...v4.27.2) (2022-07-14)
+
+
+### Bug Fixes
+
+* **SelectNative:** empty option for undefined value ([0d20f0c](https://github.com/purple-technology/phoenix-components/commit/0d20f0c9cd1e633709d2ed546184dcc599b265a6))
+
 ### [4.27.1](https://github.com/purple-technology/phoenix-components/compare/v4.27.0...v4.27.1) (2022-06-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.27.1",
+	"version": "4.27.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.27.1",
+	"version": "4.27.2",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/SelectNative/index.tsx
+++ b/src/components/SelectNative/index.tsx
@@ -59,6 +59,9 @@ export const SelectNative: React.FC<SelectNativeProps> = ({
 					disabled={props.disabled}
 					$size={size}
 				>
+					{/* Empty option must be added when no value is selected, otherwise
+						floating label is overlapping with the first selected option. */}
+					{!props.value && <option />}
 					{options.map((option, index) => (
 						<option
 							key={index}


### PR DESCRIPTION
Because of this, there's been a bug in AXIORY for at least 6 months. An empty `<option />` was there before but without the empty value condition so it was adding empty value for all native selects which was not a correct behaviour. So it was removed back then. 

This way, the option is added only when there's a discrepancy between React state (undefined value) and options in select that are all defined. Without an empty option, html select cannot be NOT defined.