### PR TITLE
Box and Notice components - improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.30.0](https://github.com/purple-technology/phoenix-components/compare/v4.29.0...v4.30.0) (2022-08-23)
+
+
+### Features
+
+* **Box:** new gap prop ([61c4ee5](https://github.com/purple-technology/phoenix-components/commit/61c4ee5897818b5fb24433d35704e46adfc8ff88))
+* **Notice:** button replaced by Button component ([e13e327](https://github.com/purple-technology/phoenix-components/commit/e13e327c3509ae4c6696a69414a886eafbf01402))
+* **Tag:** margin props ([47fd5e8](https://github.com/purple-technology/phoenix-components/commit/47fd5e841a48871846868589c8f7e57cb0a11327))
+
 ## [4.29.0](https://github.com/purple-technology/phoenix-components/compare/v4.28.0...v4.29.0) (2022-08-16)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.29.0",
+	"version": "4.30.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "4.29.0",
+	"version": "4.30.0",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/Box/BoxStyles.tsx
+++ b/src/components/Box/BoxStyles.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import {
 	background,
 	border,
@@ -11,8 +11,9 @@ import {
 
 import { marginCss, paddingCss } from '../common/Spacing/SpacingStyles'
 import { textAlignCss } from '../common/Text/TextStyles'
+import { CommonBoxProps } from './CommonBoxProps'
 
-export const StyledBox = styled.div`
+export const StyledBox = styled.div<CommonBoxProps>`
 	${layout}
 	${flexbox}
 	${grid}
@@ -23,4 +24,11 @@ export const StyledBox = styled.div`
 	${paddingCss}
 	${textAlignCss}
 	${border}
+
+	${({ gap }): FlattenSimpleInterpolation | undefined =>
+		gap
+			? css`
+					gap: ${gap};
+			  `
+			: undefined}
 `

--- a/src/components/Box/CommonBoxProps.tsx
+++ b/src/components/Box/CommonBoxProps.tsx
@@ -1,0 +1,5 @@
+import * as CSS from 'csstype'
+
+export interface CommonBoxProps {
+	gap?: CSS.Property.Gap
+}

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -16,6 +16,7 @@ import { MarginProps } from '../common/Spacing/MarginProps'
 import { PaddingProps } from '../common/Spacing/PaddingProps'
 import { TextAlignProp } from '../common/Text/CommonTextProps'
 import { StyledBox } from './BoxStyles'
+import { CommonBoxProps } from './CommonBoxProps'
 
 export interface BoxProps
 	extends Omit<HTMLAttributes<HTMLDivElement>, 'color'>,
@@ -30,7 +31,8 @@ export interface BoxProps
 		PositionProps,
 		TextAlignProp,
 		BorderProps,
-		GenericComponentProps {
+		GenericComponentProps,
+		CommonBoxProps {
 	element?: IntrinsicElementsKeys
 }
 

--- a/src/components/Notice/NoticeButton.tsx
+++ b/src/components/Notice/NoticeButton.tsx
@@ -1,44 +1,33 @@
-import React from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 
 import { ColorTheme } from '../../types/ColorTheme'
-import { ComponentSize } from '../../types/ComponentSize'
-import {
-	getBaseStyles,
-	getSizeRelatedStyles
-} from '../common/Button/ButtonStyles'
+import { Button, ButtonProps } from '../Button'
+import { Vector } from '../Spinner/SpinnerStyles'
 
-interface NoticeButtonProps {
-	onClick?: (event: React.MouseEvent) => void
-	size: ComponentSize
-	colorTheme: ColorTheme
+interface NoticeButtonProps extends Omit<ButtonProps, 'colorTheme'> {
 	breakpoint: number
+	colorTheme: ColorTheme
 }
 
-const NoticeButton = styled.button<NoticeButtonProps>`
+const NoticeButton = styled(Button)<NoticeButtonProps>`
 	grid-area: button;
-
-	${(props): FlattenSimpleInterpolation => getBaseStyles(props.theme)}
-	${(props): string => getSizeRelatedStyles('small', props.theme)}
-	
 	background: #fff;
-	box-shadow: ${({ theme }): string => theme.$pc.button.boxShadow};
 	color: ${({ theme }): string => theme.$pc.colors.text.dark};
 
-	&:hover {
-		color: #fff;
-		background: ${({ theme, colorTheme }): string =>
-			theme.$pc.colors[colorTheme].dark};
+	// Icons
+	path {
+		fill: ${({ theme }): string => theme.$pc.colors.text.dark};
 	}
-	&:focus {
-		box-shadow: 0 0 0 3px
-			${({ theme }): string =>
-				`${theme.$pc.colors.focus}, ${theme.$pc.button.boxShadow}`};
+	&:hover path {
+		fill: ${({ theme }): string => theme.$pc.colors.gray._0};
 	}
-	&[disabled] {
-		color: ${({ theme }): string => theme.$pc.notice.disabledButtonColor};
-		background: ${({ theme }): string =>
-			theme.$pc.notice.disabledButtonBackground};
+
+	// Loading spinner
+	${Vector} {
+		stroke: ${({ theme }): string => theme.$pc.colors.text.dark};
+	}
+	&:hover ${Vector} {
+		stroke: ${({ theme }): string => theme.$pc.colors.gray._0};
 	}
 
 	${({ breakpoint }): FlattenSimpleInterpolation => css`

--- a/src/components/Notice/index.tsx
+++ b/src/components/Notice/index.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
 import { ColorTheme } from '../../types/ColorTheme'
+import { IconAlignment } from '../../types/IconAlignment'
+import { IconType } from '../../types/IconType'
 import { MarginProps } from '../common/Spacing/MarginProps'
 import { PaddingProps } from '../common/Spacing/PaddingProps'
 import NoticeButton from './NoticeButton'
@@ -19,6 +21,16 @@ export interface NoticeProps
 	colorTheme?: ColorTheme
 	/** Text of the button. When supplied, button will automatically appear. `onClick` handler should be also supplied to provide functionality. */
 	buttonText?: string
+	/** Action button is loading */
+	buttonLoading?: boolean
+	/** Action button icon */
+	buttonIcon?: IconType
+	/** Action button icon alignment */
+	buttonIconAlignment?: IconAlignment
+	/** data-testid for action button */
+	buttonTestId?: string
+	/** data-testid for close button */
+	closeTestId?: string
 	/** Function to handle click on the button. */
 	onClick?: (event: React.MouseEvent) => void
 	/** Function to handle close event. When supplied, close button will automatically appear. */
@@ -35,6 +47,11 @@ export const Notice: React.FC<NoticeProps> = ({
 	onClose,
 	onClick,
 	buttonText,
+	buttonLoading = false,
+	buttonIcon,
+	buttonIconAlignment,
+	buttonTestId,
+	closeTestId,
 	...props
 }) => {
 	const py = props.py ?? (!buttonText && !onClose ? 'm' : 'xs')
@@ -71,8 +88,12 @@ export const Notice: React.FC<NoticeProps> = ({
 				<NoticeButton
 					onClick={onClick}
 					size={'small'}
+					loading={buttonLoading}
+					icon={buttonIcon}
+					iconAlignment={buttonIconAlignment}
 					colorTheme={colorTheme}
 					breakpoint={breakpoint}
+					testId={buttonTestId}
 				>
 					{buttonText}
 				</NoticeButton>
@@ -84,6 +105,7 @@ export const Notice: React.FC<NoticeProps> = ({
 					paddingLeft={!!buttonText}
 					onClick={onClose}
 					breakpoint={breakpoint}
+					data-testid={closeTestId}
 				>
 					&times;
 				</CloseButton>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
-import { ButtonColorTheme } from '../../types/ColorTheme'
+import { ColorTheme } from '../../types/ColorTheme'
 import { ComponentSize } from '../../types/ComponentSize'
 import { MarginProps } from '../common/Spacing/MarginProps'
 import { Button, Ellipsis, PaginationContainer } from './PaginationStyles'
@@ -13,7 +13,7 @@ export interface PaginationProps extends GenericComponentProps, MarginProps {
 	page: number
 	previousLabel?: string | null
 	nextLabel?: string | null
-	colorTheme?: ButtonColorTheme
+	colorTheme?: ColorTheme
 	size?: ComponentSize
 }
 

--- a/src/components/SelectPicker/SelectPickerStyles.tsx
+++ b/src/components/SelectPicker/SelectPickerStyles.tsx
@@ -6,7 +6,7 @@ import styled, {
 	ThemeProps
 } from 'styled-components'
 
-import { ButtonColorTheme } from '../../types/ColorTheme'
+import { ColorTheme } from '../../types/ColorTheme'
 import {
 	ComponentSize,
 	ComponentSizeMediumLarge
@@ -22,7 +22,7 @@ const getCheckboxOffset = (
 
 const getColor = (
 	theme: DefaultTheme,
-	colorTheme: ButtonColorTheme,
+	colorTheme: ColorTheme,
 	checked: boolean,
 	isDisabled?: boolean
 ): string => {
@@ -53,7 +53,7 @@ export const Wrapper = styled.div<WrapperProps>`
 `
 
 interface OptionDescriptionProps {
-	colorTheme: ButtonColorTheme
+	colorTheme: ColorTheme
 	checked: boolean
 	isDisabled?: boolean
 }
@@ -75,7 +75,7 @@ export const Flex = styled.div`
 interface OptionProps {
 	multiSelect: boolean
 	checked: boolean
-	colorTheme: ButtonColorTheme
+	colorTheme: ColorTheme
 	size: ComponentSizeMediumLarge
 	hasDescription: boolean
 	withImage?: string
@@ -174,7 +174,7 @@ export const OptionImage = styled.img<OptionImageProps>`
 `
 
 interface CheckboxProps {
-	colorTheme: ButtonColorTheme
+	colorTheme: ColorTheme
 	size: ComponentSize
 	checked: boolean
 }

--- a/src/components/SelectPicker/index.tsx
+++ b/src/components/SelectPicker/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
-import { ButtonColorTheme } from '../../types/ColorTheme'
+import { ColorTheme } from '../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../types/ComponentSize'
 import FormControlWarningError from '../common/FormControlWarningError'
 import {
@@ -24,7 +24,7 @@ export interface SelectPickerProps extends GenericComponentProps {
 	warning?: string
 	onMouseOver?: (event: React.MouseEvent) => void
 	onMouseLeave?: (event: React.MouseEvent) => void
-	colorTheme?: ButtonColorTheme
+	colorTheme?: ColorTheme
 	size?: ComponentSizeMediumLarge
 	/** Determines the max-width and max-height property of the <img> tag */
 	imageSize?: string

--- a/src/components/Tag/TagStyles.tsx
+++ b/src/components/Tag/TagStyles.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import { ColorTheme } from '../../types/ColorTheme'
 import { ComponentSizeSmallMedium } from '../../types/ComponentSize'
+import { marginCss } from '../common/Spacing/SpacingStyles'
 
 interface StyledTagProps {
 	colorTheme: ColorTheme
@@ -20,4 +21,6 @@ export const StyledTag = styled.div<StyledTagProps>`
 	white-space: nowrap;
 	text-align: center;
 	cursor: default;
+
+	${marginCss}
 `

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
 import { ColorTheme } from '../../types/ColorTheme'
 import { ComponentSizeSmallMedium } from '../../types/ComponentSize'
+import { MarginProps } from '../common/Spacing/MarginProps'
 import { StyledTag } from './TagStyles'
 
-export interface TagProps extends GenericComponentProps {
+export interface TagProps extends GenericComponentProps, MarginProps {
 	colorTheme?: ColorTheme
 	size?: ComponentSizeSmallMedium
 }

--- a/src/components/common/Button/ButtonStyles.tsx
+++ b/src/components/common/Button/ButtonStyles.tsx
@@ -5,7 +5,7 @@ import styled, {
 	FlattenSimpleInterpolation
 } from 'styled-components'
 
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 import { ComponentSize } from '../../../types/ComponentSize'
 import { IconAlignment } from '../../../types/IconAlignment'
 import { IconType } from '../../../types/IconType'
@@ -26,7 +26,7 @@ export const getSizeRelatedStyles = (
 
 export const getColorThemeStyles = (
 	theme: DefaultTheme,
-	colorTheme: ButtonColorTheme,
+	colorTheme: ColorTheme,
 	minimal?: boolean,
 	light?: boolean
 ): string => {
@@ -139,7 +139,7 @@ export const ButtonContent = styled.div<ButtonContentProps>`
 
 interface ButtonWrapperProps {
 	size: ComponentSize
-	colorTheme: ButtonColorTheme
+	colorTheme: ColorTheme
 	minimal?: boolean
 	light?: boolean
 	icon?: IconType

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 import { ComponentSize } from '../../../types/ComponentSize'
 import { IconAlignment } from '../../../types/IconAlignment'
 import { IconType } from '../../../types/IconType'
@@ -11,7 +11,7 @@ import { ButtonContent, ButtonLoader, ButtonText } from './ButtonStyles'
 
 export interface CommonButtonProps extends MarginProps {
 	/** Theme of the button - background color */
-	colorTheme?: ButtonColorTheme
+	colorTheme?: ColorTheme
 	/** Size of the button; affects padding, line-height, and font-size */
 	size?: ComponentSize
 	/** Minimal styling of the button - no background, border etc. */

--- a/src/components/common/Button/stories.tsx
+++ b/src/components/common/Button/stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 import { ComponentSize } from '../../../types/ComponentSize'
 import { IconAlignment } from '../../../types/IconAlignment'
 import { PhoenixIconsOutlined } from '../../../types/PhoenixIcons'
@@ -15,7 +15,7 @@ export const argTypes = {
 		defaultValue: 'medium'
 	},
 	colorTheme: {
-		options: ButtonColorTheme,
+		options: ColorTheme,
 		defaultValue: 'primary'
 	},
 	iconAlignment: {

--- a/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
+++ b/src/components/common/CheckboxRadio/CheckboxRadioStyles.tsx
@@ -1,11 +1,11 @@
 import styled, { DefaultTheme } from 'styled-components'
 
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../../types/ComponentSize'
 import { left } from '../../../utils/rtl'
 
 export interface CommonStyledCheckboxRadioProps {
-	colorTheme: ButtonColorTheme
+	colorTheme: ColorTheme
 	size: ComponentSizeMediumLarge
 	/** Show yellow warning text and icon under the input */
 	warning?: boolean

--- a/src/components/common/CheckboxRadio/index.tsx
+++ b/src/components/common/CheckboxRadio/index.tsx
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid'
 import React, { InputHTMLAttributes } from 'react'
 
 import { GenericComponentProps } from '../../../interfaces/GenericComponentProps'
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 import { ComponentSizeMediumLarge } from '../../../types/ComponentSize'
 import {
 	FormControlErrorType,
@@ -15,7 +15,7 @@ export interface CheckboxRadioCommonProps
 		GenericComponentProps {
 	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
 	RTL?: boolean
-	colorTheme?: ButtonColorTheme
+	colorTheme?: ColorTheme
 	size?: ComponentSizeMediumLarge
 	label?: React.ReactNode
 	/** Show yellow warning text and icon under the input */

--- a/src/components/common/CheckboxRadio/stories.tsx
+++ b/src/components/common/CheckboxRadio/stories.tsx
@@ -1,4 +1,4 @@
-import { ButtonColorTheme } from '../../../types/ColorTheme'
+import { ColorTheme } from '../../../types/ColorTheme'
 
 export const argTypes = {
 	/** Prop error was by default JSON but we need text. */
@@ -17,7 +17,7 @@ export const argTypes = {
 		defaultValue: 'medium'
 	},
 	colorTheme: {
-		options: ButtonColorTheme,
+		options: ColorTheme,
 		defaultValue: 'primary'
 	},
 	disabled: {

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -56,11 +56,21 @@ const colors = {
 	},
 	warning: {
 		dark: '#CB7307',
-		light: '#FBF6E9'
+		darkHoverBackground: '#CB7307',
+		darkDisabledBackground: '#E8CBA7',
+		light: '#FBF6E9',
+		lightHoverBackground: '#F4E9CB',
+		lightDisabledBackground: '#FDF9EF',
+		lightDisabledColor: '#EDC089'
 	},
 	info: {
 		dark: '#3F75AC',
-		light: '#F2F7FC'
+		darkHoverBackground: '#3F75AC',
+		darkDisabledBackground: '#9EBFE1',
+		light: '#F2F7FC',
+		lightHoverBackground: '#E3ECF5',
+		lightDisabledBackground: '#F2F7FC',
+		lightDisabledColor: '#A5C4E3'
 	},
 	gray,
 

--- a/src/types/ColorTheme.tsx
+++ b/src/types/ColorTheme.tsx
@@ -7,11 +7,3 @@ export const ColorTheme = [
 	'neutral'
 ] as const
 export type ColorTheme = typeof ColorTheme[number]
-
-export const ButtonColorTheme = [
-	'primary',
-	'success',
-	'error',
-	'neutral'
-] as const
-export type ButtonColorTheme = typeof ButtonColorTheme[number]


### PR DESCRIPTION
- new `gap` prop in `Box` component
- added margin props to `Tag` component
- added theme colors for warning and info
- removed `ButtonColorTheme` and everywhere is now used only `ColorTheme` type
- in `Notice` component `Button` component is used now instead of a separately styled `button` tag
- many new props for an action button in `Notice` component
