### PR TITLE
LAB-17: Remove deprecated RTL props

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -16,8 +16,6 @@ export const Checkbox: React.VoidFunctionComponent<CheckboxProps> = ({
 	className,
 	warning,
 	error,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	RTL,
 	testId = 'Checkbox',
 	...props
 }) => (

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -70,8 +70,6 @@ export interface DateInputProps extends GenericComponentProps {
 	dateFormatError?: string
 	/** The locality the date format should follow */
 	locale?: 'eu' | 'us' | 'ja'
-	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
-	RTL?: boolean
 	size?: SizingSmMdLg
 	disabled?: boolean
 	/** For use with Formik (but possibly other frameworks that work with the concept of a field being "touched"). */

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -16,8 +16,6 @@ export const Radio: React.VoidFunctionComponent<RadioProps> = ({
 	className,
 	warning,
 	error,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	RTL,
 	testId = 'Radio',
 	...props
 }) => (

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -21,8 +21,6 @@ export const TextArea: React.FC<TextAreaProps> = ({
 	error,
 	contentRight,
 	helperText,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	RTL,
 	className,
 	...props
 }) => {

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -21,8 +21,6 @@ export const TextInput: React.FC<TextInputProps> = ({
 	error,
 	contentRight,
 	helperText,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	RTL,
 	className,
 	...props
 }) => {

--- a/src/components/common/CheckboxRadio/index.tsx
+++ b/src/components/common/CheckboxRadio/index.tsx
@@ -13,8 +13,6 @@ import { Label } from './CheckboxRadioStyles'
 export interface CheckboxRadioCommonProps
 	extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>,
 		GenericComponentProps {
-	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
-	RTL?: boolean
 	colorTheme?: ColorTheme
 	size?: SizingSmMdLg
 	label?: React.ReactNode

--- a/src/components/common/FormControl/index.tsx
+++ b/src/components/common/FormControl/index.tsx
@@ -29,8 +29,6 @@ export interface FormControlProps extends GenericComponentProps {
 	contentRight?: string | React.ReactNode
 	/** Helper text to display when input is focused */
 	helperText?: string
-	/** @deprecated RTL is unnecessary, unsed and will be removed in the next major version. */
-	RTL?: boolean
 	size?: Sizing
 	disabled?: boolean
 	focused?: boolean
@@ -48,8 +46,6 @@ const FormControl: React.FC<PropsWithChildren<FormControlInternalProps>> = ({
 	error,
 	contentRight,
 	helperText,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	RTL,
 	className,
 	disabled = false,
 	focused,


### PR DESCRIPTION
Throughout the components, there are RTL props. These props were deprecated and we want to remove them in all components in version 5.

### Linear:
[LAB-17: Remove deprecated RTL props](https://linear.app/purple-technology/issue/LAB-17/remove-deprecated-rtl-props)