### PR TITLE
Modal fix - animation false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.0.0-beta.4](https://github.com/purple-technology/phoenix-components/compare/v5.0.0-beta.3...v5.0.0-beta.4) (2023-03-02)
+
+
+### Bug Fixes
+
+* **Modal:** closing when animate is false ([1613615](https://github.com/purple-technology/phoenix-components/commit/16136150dd405948a757676e1395d2adf9168251))
+
 ## [5.0.0-beta.3](https://github.com/purple-technology/phoenix-components/compare/v5.0.0-beta.2...v5.0.0-beta.3) (2023-03-02)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "5.0.0-beta.3",
+	"version": "5.0.0-beta.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 	"scripts": {
 		"lint": "eslint 'src' '.storybook' --ext .ts,.tsx,.js,.jsx,.json,.d.ts",
 		"lint:fix": "eslint 'src' '.storybook' --ext .ts,.tsx,.js,.jsx,.json,.d.ts --fix",
-		"build:tokens": "(git -C my-axiory-tokens pull || git clone https://github.com/purple-technology/my-axiory-tokens.git) && node style-dictionary-build && eslint 'src/tokens/' --ext .json --fix",
+		"tokens": "(git -C my-axiory-tokens pull || git clone https://github.com/purple-technology/my-axiory-tokens.git) && npm run build:tokens",
+		"build:tokens": "node style-dictionary-build && eslint 'src/tokens/' --ext .json --fix",
 		"build": "rollup -c && rm -r ./dist/types",
 		"build-watch": "rollup -c -w",
 		"prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "5.0.0-beta.3",
+	"version": "5.0.0-beta.4",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -56,9 +56,13 @@ export const Modal: React.FC<PropsWithChildren<ModalProps>> = ({
 			setRendered(true)
 		} else {
 			setVisible(false)
-			windowRef.current?.addEventListener('transitionend', () =>
+			if (animate) {
+				windowRef.current?.addEventListener('transitionend', () =>
+					setRendered(false)
+				)
+			} else {
 				setRendered(false)
-			)
+			}
 		}
 	}, [open])
 


### PR DESCRIPTION
Fixed bug that left Modal rendered but invisible (and you couldn't interact with other elements on the page) in scenario where animation is disabled (`animate === false`)

Plus I made two scripts out of the original one `tokens:build` because I sometimes need to update the tokens locally and in that case I want to only build them, but not pull them from repo.