### PR TITLE
PLT-77 ci: bump percy node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: npm run test
   percy:
     docker:
-      - image: cimg/node:16.20.0
+      - image: cimg/node:18.12.1
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
@theskupi reported issue with Percy screenshots in CI.

I've fixed this by bumping image version to node 18 as the rest of the project.