### PR TITLE
fix: missing validation for min number

### DIFF
--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -150,7 +150,7 @@ export const DateInput: React.FC<DateInputProps> = ({
 	const dayComponent = (
 		<NumberInput
 			name="day"
-			min="1"
+			min={1}
 			pattern="[0-9]*"
 			autoComplete="bday-day"
 			label={labels.day}
@@ -184,7 +184,7 @@ export const DateInput: React.FC<DateInputProps> = ({
 	const yearComponent = (
 		<NumberInput
 			name="year"
-			min="1"
+			min={1}
 			autoComplete="bday-year"
 			pattern="[0-9]*"
 			label={labels.year}

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -15,6 +15,8 @@ export interface NumberInputProps
 	onChange: (value: number | null) => void
 	numberFormatErrorMessage?: string
 	maxDecimalCount?: number
+	min?: number
+	numberBelowMinErrorMessage?: string
 }
 
 /**
@@ -35,7 +37,9 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 	onFocus,
 	onBlur,
 	numberFormatErrorMessage = 'Wrong number format',
+	numberBelowMinErrorMessage = 'Number is below minimum',
 	maxDecimalCount = 2,
+	min,
 	...props
 }) => {
 	const inputRef = useRef<HTMLInputElement>(null)
@@ -58,9 +62,14 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 					textValue,
 					maxDecimalCount
 				)
-				onChange(numberValue)
-				setTextValue(stringValue)
-				setInternalError(undefined)
+				if (min !== undefined && numberValue < min) {
+					onChange(null)
+					setInternalError(numberBelowMinErrorMessage)
+				} else {
+					onChange(numberValue)
+					setTextValue(stringValue)
+					setInternalError(undefined)
+				}
 			} else {
 				onChange(null)
 				setInternalError(numberFormatErrorMessage)


### PR DESCRIPTION
There was already a `min` prop in DateInput component, but it wasn't doing anything. I changed it to number and added validation for it.