### PR TITLE
feat: adding children props to FC components

### DIFF
--- a/src/components/ClosableItem/index.tsx
+++ b/src/components/ClosableItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 
 import iconTimes from '../../images/times.svg'
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
@@ -9,7 +9,7 @@ export interface ClosableItemProps extends GenericComponentProps {
 	onClose?: React.MouseEventHandler<HTMLButtonElement>
 }
 
-export const ClosableItem: React.FC<ClosableItemProps> = ({
+export const ClosableItem: React.FC<PropsWithChildren<ClosableItemProps>> = ({
 	testId = 'ClosableItem',
 	className,
 	onClose,

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 
 import { GenericComponentProps } from '../../interfaces/GenericComponentProps'
 import { ColorTheme } from '../../types/Color'
@@ -13,7 +13,7 @@ export interface TagProps extends GenericComponentProps, MarginProps {
 	outline?: boolean
 }
 
-export const Tag: React.FC<TagProps> = ({
+export const Tag: React.FC<PropsWithChildren<TagProps>> = ({
 	colorTheme = 'brand',
 	size = 'md',
 	testId = 'Tag',


### PR DESCRIPTION
Adding props with children to the Tag and ClosableItem components. These steps are necessary for further React upgrade in projects