### PR TITLE
chore: reverting tabs to older version for temporary React 17 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.24.4](https://github.com/purple-technology/phoenix-components/compare/v5.24.3...v5.24.4) (2025-06-23)
+
 ### [5.24.3](https://github.com/purple-technology/phoenix-components/compare/v5.24.2...v5.24.3) (2025-06-19)
 
 ### [5.24.2](https://github.com/purple-technology/phoenix-components/compare/v5.24.1...v5.24.2) (2025-06-09)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"react-inlinesvg": "~3.0.1",
 		"react-pdf": "~8.0.2",
 		"react-select": "^5.7.0",
-		"react-tabs": "^6.1.0",
+		"react-tabs": "^4.2.1",
 		"styled-system": "~5.1.5",
 		"zxcvbn": "~4.4.2"
 	},
@@ -113,7 +113,7 @@
 		"@types/node": "^20.4.7",
 		"@types/react": "^18.0.20",
 		"@types/react-dom": "^18.0.6",
-		"@types/react-tabs": "^5.0.5",
+		"@types/react-tabs": "^2.3.4",
 		"@types/styled-components": "^5.1.26",
 		"@types/styled-system": "^5.1.13",
 		"@types/zxcvbn": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@purple/phoenix-components",
-	"version": "5.24.3",
+	"version": "5.24.4",
 	"description": "",
 	"main": "dist/bundle.umd.js",
 	"module": "dist/bundle.esm.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^5.7.0
         version: 5.7.0(@types/react@18.0.20)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-tabs:
-        specifier: ^6.1.0
-        version: 6.1.0(react@18.2.0)
+        specifier: ^4.2.1
+        version: 4.3.0(react@18.2.0)
       styled-system:
         specifier: ~5.1.5
         version: 5.1.5
@@ -175,8 +175,8 @@ importers:
         specifier: ^18.0.6
         version: 18.0.6
       '@types/react-tabs':
-        specifier: ^5.0.5
-        version: 5.0.5(react@18.2.0)
+        specifier: ^2.3.4
+        version: 2.3.4
       '@types/styled-components':
         specifier: ^5.1.26
         version: 5.1.26
@@ -3079,9 +3079,8 @@ packages:
   '@types/react-dom@18.0.6':
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
 
-  '@types/react-tabs@5.0.5':
-    resolution: {integrity: sha512-3CZTmjR7nNrZnYbnxp/DtK5e82mhM22dN47aYObmYLcp9fC1XjIEF0mLzGKFl1fR6/R8X7DyGh9hO6lON6LVkQ==}
-    deprecated: This is a stub types definition. react-tabs provides its own type definitions, so you do not need this installed.
+  '@types/react-tabs@2.3.4':
+    resolution: {integrity: sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==}
 
   '@types/react-transition-group@4.4.6':
     resolution: {integrity: sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==}
@@ -3840,6 +3839,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -6970,10 +6973,10 @@ packages:
       '@types/react':
         optional: true
 
-  react-tabs@6.1.0:
-    resolution: {integrity: sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==}
+  react-tabs@4.3.0:
+    resolution: {integrity: sha512-2GfoG+f41kiBIIyd3gF+/GRCCYtamC8/2zlAcD8cqQmqI9Q+YVz7fJLHMmU9pXDVYYHpJeCgUSBJju85vu5q8Q==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0-0 || ^18.0.0
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -12156,11 +12159,9 @@ snapshots:
     dependencies:
       '@types/react': 18.0.20
 
-  '@types/react-tabs@5.0.5(react@18.2.0)':
+  '@types/react-tabs@2.3.4':
     dependencies:
-      react-tabs: 6.1.0(react@18.2.0)
-    transitivePeerDependencies:
-      - react
+      '@types/react': 18.0.20
 
   '@types/react-transition-group@4.4.6':
     dependencies:
@@ -13087,6 +13088,8 @@ snapshots:
       shallow-clone: 3.0.1
 
   clone@1.0.4: {}
+
+  clsx@1.2.1: {}
 
   clsx@2.1.1: {}
 
@@ -16946,9 +16949,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.0.20
 
-  react-tabs@6.1.0(react@18.2.0):
+  react-tabs@4.3.0(react@18.2.0):
     dependencies:
-      clsx: 2.1.1
+      clsx: 1.2.1
       prop-types: 15.8.1
       react: 18.2.0
 


### PR DESCRIPTION
Reverting tabs upgrade due to compability with React v17 which is still used in Axiory. Once the pull request with upgrade is go to, we will create release minor version with this upgrade 