### PR TITLE
FX-1398: Individual/Corporate tabs underlining have incorrect length

### DIFF
--- a/src/components/Tabs/ActiveTabIndicator.tsx
+++ b/src/components/Tabs/ActiveTabIndicator.tsx
@@ -46,7 +46,7 @@ const ActiveTabIndicator: React.FC<ActiveTabIndicatorProps> = ({
 				tabIndex++
 			}
 		})
-	}, [selectedIndex])
+	}, [selectedIndex, tabs, tabRefs])
 
 	return (
 		<StyledIndicator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab indicator not updating correctly when tabs or tab references change unexpectedly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->